### PR TITLE
Captagent6: some fixes whil bilding on CentOS6 x86_64

### DIFF
--- a/captagent.spec.in
+++ b/captagent.spec.in
@@ -28,8 +28,8 @@ autoreconf -if
 
 %files
 %defattr(644,root,root,755)
-%{_sysconfdir}/%name/*
-%{_bindir}/%name
+%config(noreplace) %{_sysconfdir}/%name/*
+%attr(755,root,root) %{_bindir}/%name
 # Ugly-ugly hack: do not search for modules
 #%{_libdir}/%name/modules/*.so
 #%{_libdir}/%name/modules/*.la

--- a/src/conf_function.h
+++ b/src/conf_function.h
@@ -82,7 +82,6 @@ struct action* append_action(struct action* a, struct action* b);
 void print_action(struct action* a);
 void print_expr(struct expr* exp);
 
-typedef  int (*fixup_function)(void** param, int param_no);
 typedef  int (*response_function)(struct sip_msg*);
 typedef int (*child_init_function)(int rank);
 


### PR DESCRIPTION
+ Removed fixup_function def from conf_function.h
+ Added X attribute to main executable for captagent application