### PR TITLE
Ensure link offset of proto_rtcp mod does not clash with proto_uni mod

### DIFF
--- a/captagent/mod/proto_rtcp/proto_rtcp.c
+++ b/captagent/mod/proto_rtcp/proto_rtcp.c
@@ -60,7 +60,7 @@
 #include "../proto_uni/capthash.h"
 #include "rtcp_parser.h"
 
-uint8_t link_offset = 14;
+static uint8_t rtcp_link_offset = 14;
 uint8_t hdr_offset = 0;
 
 pcap_t *sniffer_rtp;
@@ -85,9 +85,9 @@ void rtcpback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
           }
         }
 
-        struct ip      *ip4_pkt = (struct ip *)    (packet + link_offset + hdr_offset);
+        struct ip      *ip4_pkt = (struct ip *)    (packet + rtcp_link_offset + hdr_offset);
 #if USE_IPv6
-        struct ip6_hdr *ip6_pkt = (struct ip6_hdr*)(packet + link_offset + ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4: 0) );
+        struct ip6_hdr *ip6_pkt = (struct ip6_hdr*)(packet + rtcp_link_offset + ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4: 0) );
 #endif
 
 	uint32_t ip_ver;
@@ -157,7 +157,7 @@ void rtcpback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
 
                     data = (unsigned char *)(udp_pkt) + udphdr_offset;
                     
-                    len -= link_offset + ip_hl + udphdr_offset + hdr_offset;
+                    len -= rtcp_link_offset + ip_hl + udphdr_offset + hdr_offset;
 
 #if USE_IPv6
                     if (ip_ver == 6)
@@ -302,43 +302,43 @@ void* rtp_collect( void* device ) {
 
         if(filter_expr) free(filter_expr);
         
-        /* detect link_offset. Thanks ngrep for this. */
+        /* detect rtcp_link_offset. Thanks ngrep for this. */
         switch(pcap_datalink(sniffer_rtp)) {
                 case DLT_EN10MB:
-                    link_offset = ETHHDR_SIZE;
+                    rtcp_link_offset = ETHHDR_SIZE;
                     break;
 
                 case DLT_IEEE802:
-                    link_offset = TOKENRING_SIZE;
+                    rtcp_link_offset = TOKENRING_SIZE;
                     break;
 
                 case DLT_FDDI:
-                    link_offset = FDDIHDR_SIZE;
+                    rtcp_link_offset = FDDIHDR_SIZE;
                     break;
 
                 case DLT_SLIP:
-                    link_offset = SLIPHDR_SIZE;
+                    rtcp_link_offset = SLIPHDR_SIZE;
                     break;
 
                 case DLT_PPP:
-                    link_offset = PPPHDR_SIZE;
+                    rtcp_link_offset = PPPHDR_SIZE;
                     break;
 
                 case DLT_LOOP:
                 case DLT_NULL:
-                    link_offset = LOOPHDR_SIZE;
+                    rtcp_link_offset = LOOPHDR_SIZE;
                     break;
 
                 case DLT_RAW:
-                    link_offset = RAWHDR_SIZE;
+                    rtcp_link_offset = RAWHDR_SIZE;
                     break;
 
                 case DLT_LINUX_SLL:
-                    link_offset = ISDNHDR_SIZE;
+                    rtcp_link_offset = ISDNHDR_SIZE;
                     break;
 
                 case DLT_IEEE802_11:
-                    link_offset = IEEE80211HDR_SIZE;
+                    rtcp_link_offset = IEEE80211HDR_SIZE;
                     break;
 
                 default:

--- a/captagent/mod/proto_uni/proto_uni.c
+++ b/captagent/mod/proto_uni/proto_uni.c
@@ -67,7 +67,7 @@
 #include "captarray.h"
 #include "capthash.h"
 
-uint8_t link_offset = 14;
+static uint8_t link_offset = 14;
 
 pcap_t *sniffer_proto;
 pthread_t call_thread;   


### PR DESCRIPTION
While testing a capture with device "any" for proto_uni, I noticed that packets were received but not recognized as IPv4 nor IPv6, and the packets discarded. Specifying the device (e.g. 'lo') was instead working correctly.
Experimenting with changes to the offset I noticed - coincidentally - that there was a wrong offset of 2: adding a fixed 2 to link_offset made the capture work for device "any" too. I then noticed that proto_uni was correctly setting link_offset to 16 (DLT_LINUX_SLL), but then at the moment of entering into the callback function link_offset was back to 14. The interpretation is that link_offset from proto_rtcp was causing the reset.
This pull request sets link_offset as static, then changes the variable name for proto_rtcp.
I have tested proto_uni with this patch and works well with both the device name and "any". I have not had the chance to test proto_rtcp after the changes.