### PR TITLE
Fix Debian packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,10 +37,13 @@ capplan.tab.h
 lex.yy.c
 ylwrap
 captagent.spec
+conf/captagent.xml
 pkg/debian/*.substvars
 pkg/debian/*.debhelper
 pkg/debian/*.debhelper.log
 pkg/debian/files
 pkg/debian/captagent/
+pkg/debian/captagent.init
+src/captagent
 *.dh-orig
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ stamp-h1
 *.la
 *.Po
 *.Plo
+.*.swp
 .deps
 .libs
 autom4te.cache
@@ -35,3 +36,11 @@ ltversion.m4
 capplan.tab.h
 lex.yy.c
 ylwrap
+captagent.spec
+pkg/debian/*.substvars
+pkg/debian/*.debhelper
+pkg/debian/*.debhelper.log
+pkg/debian/files
+pkg/debian/captagent/
+*.dh-orig
+

--- a/conf/captagent.xml.in
+++ b/conf/captagent.xml.in
@@ -10,10 +10,10 @@
 		<param name="syslog" value="false"/>
 		<param name="pid_file" value="/var/run/captagent.pid"/>
 		<!-- Configure using installation path if different from default -->
-		<param name="module_path" value="/usr/local/captagent/lib/captagent/modules"/>
-		<param name="config_path" value="/usr/local/captagent/etc/captagent"/>
-		<param name="capture_plans_path" value="/usr/local/captagent/etc/captagent/captureplans"/>
-		<param name="backup" value="/usr/local/captagent/etc/captagent/backup"/>
+		<param name="module_path" value="@module_dir@"/>
+		<param name="config_path" value="@sysconfdir@/captagent"/>
+		<param name="capture_plans_path" value="@sysconfdir@/captagent/captureplans"/>
+		<param name="backup" value="@sysconfdir@/captagent/backup"/>
 		<param name="chroot" value="/usr/local/captagent"/>
 	    </settings>
 	</configuration>

--- a/configure.ac
+++ b/configure.ac
@@ -13,12 +13,14 @@ if test "$prefix" = "NONE"; then
    prefix=$ac_default_prefix
 fi
 
-agent_config_dir="$sysconfdir/captagent/"
-agent_plan_dir="$sysconfdir/captagent/"
+AS_AC_EXPAND(agent_config_dir, "$sysconfdir/captagent/")
+AS_AC_EXPAND(agent_plan_dir, "$sysconfdir/captagent/")
+AS_AC_EXPAND(module_dir, "$libdir/captagent/modules")
 
 AC_DEFINE_UNQUOTED(AGENT_PREFIX, ["$prefix"], [our system prefix])
 AC_DEFINE_UNQUOTED(AGENT_CONFIG_DIR, ["$agent_config_dir"], [captagent config dir])
 AC_DEFINE_UNQUOTED(AGENT_PLAN_DIR, ["$agent_plan_dir"], [capture plans dir])
+AC_DEFINE_UNQUOTED(MODULE_DIR, ["$module_dir"], [directory that modules will be installed to])
 
 enableCompression=no
 AC_ARG_ENABLE(compression,

--- a/configure.ac
+++ b/configure.ac
@@ -310,6 +310,7 @@ AC_CONFIG_FILES([
 	captagent.spec
 	include/Makefile
 	src/Makefile
+	conf/captagent.xml
 ])
 
 m4_include([m4/modules_makefiles.m4])

--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,8 @@ if test "$prefix" = "NONE"; then
    prefix=$ac_default_prefix
 fi
 
-agent_config_dir=$sysconfdir"/etc/captagent/"
-agent_plan_dir=$sysconfdir"/etc/captagent/"
+agent_config_dir="$sysconfdir/captagent/"
+agent_plan_dir="$sysconfdir/captagent/"
 
 AC_DEFINE_UNQUOTED(AGENT_PREFIX, ["$prefix"], [our system prefix])
 AC_DEFINE_UNQUOTED(AGENT_CONFIG_DIR, ["$agent_config_dir"], [captagent config dir])

--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,8 @@ if test "$prefix" = "NONE"; then
    prefix=$ac_default_prefix
 fi
 
-agent_config_dir=$prefix"/etc/captagent/"
-agent_plan_dir=$prefix"/etc/captagent/"
+agent_config_dir=$sysconfdir"/etc/captagent/"
+agent_plan_dir=$sysconfdir"/etc/captagent/"
 
 AC_DEFINE_UNQUOTED(AGENT_PREFIX, ["$prefix"], [our system prefix])
 AC_DEFINE_UNQUOTED(AGENT_CONFIG_DIR, ["$agent_config_dir"], [captagent config dir])

--- a/configure.ac
+++ b/configure.ac
@@ -311,6 +311,7 @@ AC_CONFIG_FILES([
 	include/Makefile
 	src/Makefile
 	conf/captagent.xml
+	pkg/debian/captagent.init
 ])
 
 m4_include([m4/modules_makefiles.m4])

--- a/include/captagent/modules.h
+++ b/include/captagent/modules.h
@@ -27,8 +27,6 @@
 #ifndef MODULES_H_
 #define MODULES_H_
 
-#define MODULE_DIR "/usr/local/lib/captagent/modules"
-
 char *module_path;
 
 #define VAR_PARAM_NO  -128

--- a/m4/as-ac-expand.m4
+++ b/m4/as-ac-expand.m4
@@ -1,0 +1,49 @@
+dnl as-ac-expand.m4 0.2.0                                   -*- autoconf -*-
+dnl autostars m4 macro for expanding directories using configure's prefix
+
+dnl (C) 2003, 2004, 2005 Thomas Vander Stichele <thomas at apestaart dot org>
+
+dnl Copying and distribution of this file, with or without modification,
+dnl are permitted in any medium without royalty provided the copyright
+dnl notice and this notice are preserved.
+
+dnl AS_AC_EXPAND(VAR, CONFIGURE_VAR)
+
+dnl example:
+dnl AS_AC_EXPAND(SYSCONFDIR, $sysconfdir)
+dnl will set SYSCONFDIR to /usr/local/etc if prefix=/usr/local
+
+AC_DEFUN([AS_AC_EXPAND],
+[
+  EXP_VAR=[$1]
+  FROM_VAR=[$2]
+
+  dnl first expand prefix and exec_prefix if necessary
+  prefix_save=$prefix
+  exec_prefix_save=$exec_prefix
+
+  dnl if no prefix given, then use /usr/local, the default prefix
+  if test "x$prefix" = "xNONE"; then
+    prefix="$ac_default_prefix"
+  fi
+  dnl if no exec_prefix given, then use prefix
+  if test "x$exec_prefix" = "xNONE"; then
+    exec_prefix=$prefix
+  fi
+
+  full_var="$FROM_VAR"
+  dnl loop until it doesn't change anymore
+  while true; do
+    new_full_var="`eval echo $full_var`"
+    if test "x$new_full_var" = "x$full_var"; then break; fi
+    full_var=$new_full_var
+  done
+
+  dnl clean up
+  full_var=$new_full_var
+  AC_SUBST([$1], "$full_var")
+
+  dnl restore prefix and exec_prefix
+  prefix=$prefix_save
+  exec_prefix=$exec_prefix_save
+])

--- a/pkg/debian/captagent.init.in
+++ b/pkg/debian/captagent.init.in
@@ -8,7 +8,7 @@
 # Required-Stop:
 # Short-Description: captagent - the Open Source Homer Capture Agent
 # Description: Homer captagent is an Open Source Capture Programm released
-# 	under GPLv3, able to handle thousands of call setups per second.
+#	under GPLv3, able to handle thousands of call setups per second.
 ### END INIT INFO
 
 cap=/usr/bin/captagent
@@ -20,7 +20,7 @@ RETVAL=0
 start() {
   if [ -e $pidfile ]; then
         echo "[FAILED] Captagent is already running with PID: `cat $pidfile`"
-  else      
+  else
         echo -n "Starting $prog: "
         # there is something at end of this output which is needed to
         # report proper [ OK ] status in CentOS scripts
@@ -44,7 +44,6 @@ stop() {
 		echo
 		[ $RETVAL = 1 ] && rm -f $lockfile $pidfile
 		echo "[FAILED] Captagent is not running"
-                
 	fi
 }
 
@@ -57,14 +56,13 @@ status() {
                         echo "[FAILED] Captagent is not running"
                         RETVAL=1
         fi
-        
 	return $RETVAL
 }
 
 
 
 
-[ -z "$CONFIG" ]  && CONFIG=/usr/local/etc/captagent/captagent.xml
+[ -z "$CONFIG" ]  && CONFIG=@sysconfdir@/captagent/captagent.xml
 
 OPTIONS="-d -f $CONFIG"
 

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -9,7 +9,7 @@ export DH_OPTIONS
 
 build:
 	autoreconf -if
-	./configure --prefix=/usr
+	./configure --prefix=/usr --sysconfdir=/etc
 	make
 
 binary-arch:

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -9,7 +9,7 @@ export DH_OPTIONS
 
 build:
 	autoreconf -if
-	./configure --prefix=/usr --sysconfdir=/etc
+	./configure --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	make
 
 binary-arch:


### PR DESCRIPTION
This patch set updates the Debian packaging and other aspects of the build system to make sure that a Debian package can be built and is usable immediately after installation without any manual config.

packaging is possible with the following commands

```
ln -s pkg/debian
debuild -uc -us
```