### PR TITLE
debian pkg: require libuv1(-dev) and make init script use default file

### DIFF
--- a/pkg/debian/captagent.default
+++ b/pkg/debian/captagent.default
@@ -2,9 +2,5 @@
 # sourced by /etc/init.d/captagent
 # installed at /etc/default/captagent by the maintainer scripts
 
-#
-# This is a POSIX shell fragment
-#
+RUN_CAPTAGENT=no
 
-# Additional options that are passed to the Daemon.
-DAEMON_OPTS=""

--- a/pkg/debian/captagent.init.in
+++ b/pkg/debian/captagent.init.in
@@ -15,6 +15,7 @@ cap=/usr/bin/captagent
 prog=captagent
 pidfile=/var/run/$prog.pid
 lockfile=/var/lock/$prog
+DEFAULTS=/etc/default/$prog
 RETVAL=0
 
 start() {
@@ -60,6 +61,15 @@ status() {
 }
 
 
+# Load startup options if available
+if [ -f $DEFAULTS ]; then
+	. $DEFAULTS || true
+fi
+
+if [ "$RUN_CAPTAGENT" != "yes" ]; then
+	echo "Captagent not yet configured. Edit /etc/default/$prog first."
+	exit 0
+fi
 
 
 [ -z "$CONFIG" ]  && CONFIG=@sysconfdir@/captagent/captagent.xml

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -11,14 +11,15 @@ Build-Depends:	debhelper (>= 8.0.0),
 		libexpat-dev,
 		libjson0-dev,
 		libmysqlclient-dev,
-		libpcap0.8-dev
+		libpcap0.8-dev,
+		libuv1-dev
 Standards-Version: 6.0.1
 Homepage: http://sipcapture.org
 Vcs-Git: git://github.com/sipcapture/captagent/tree/captagent6
 
 Package: captagent
 Architecture: linux-any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libpcap0.8, libexpat1
+Depends: ${shlibs:Depends}, ${misc:Depends}, libpcap0.8, libexpat1, libuv1
 Description: SIP capture server
  HOMER5 a robust, carrier-grade, scalable SIP Capture system and Monitoring Application with HEP/HEP2, IP Proto4 (IPIP) encapsulation & port mirroring/monitoring support right out of the box, ready to process & store insane amounts of signaling with instant search, end-to-end analysis and drill-down capabilities for ITSPs, VoIP Providers and Trunk Suppliers using SIP signaling
 


### PR DESCRIPTION
We are creating debian packages for captagent, but we don't run them via init script. So I added a pretty basic defaults file, which makes captagent by default not start because the RUN_CAPTAGENT variable is set to "no". Before the first start, you probably want to edit the configuration anyways. 

Also, there is a new dependency to libuv1, so I added that. But since this lib is not available in Wheezy, you need at least Jessie for the package to build.