### PR TITLE
libuv1 packages do not exist on debian

### DIFF
--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -12,14 +12,14 @@ Build-Depends:	debhelper (>= 8.0.0),
 		libjson0-dev,
 		libmysqlclient-dev,
 		libpcap0.8-dev,
-		libuv1-dev
+		libuv0.10-dev
 Standards-Version: 6.0.1
 Homepage: http://sipcapture.org
 Vcs-Git: git://github.com/sipcapture/captagent/tree/captagent6
 
 Package: captagent
 Architecture: linux-any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libpcap0.8, libexpat1, libuv1
+Depends: ${shlibs:Depends}, ${misc:Depends}, libpcap0.8, libexpat1, libuv0.10
 Description: SIP capture server
  HOMER5 a robust, carrier-grade, scalable SIP Capture system and Monitoring Application with HEP/HEP2, IP Proto4 (IPIP) encapsulation & port mirroring/monitoring support right out of the box, ready to process & store insane amounts of signaling with instant search, end-to-end analysis and drill-down capabilities for ITSPs, VoIP Providers and Trunk Suppliers using SIP signaling
 


### PR DESCRIPTION
I updated the package dependency from libuv1, which doesn't exist on Debian, to libuv0.10, which exists on both Debian and Ubuntu.