### PR TITLE
pcap: Add initial version of sctp support

### DIFF
--- a/include/captagent/structure.h
+++ b/include/captagent/structure.h
@@ -35,6 +35,7 @@ typedef struct msg {
         uint32_t len;
         uint16_t hdr_len;
         uint8_t tcpflag;
+        uint32_t sctp_ppid;
         rc_info_t rcinfo;
         uint8_t parse_it;
         void *parsed_data;

--- a/src/modules/socket/pcap/Makefile.am
+++ b/src/modules/socket/pcap/Makefile.am
@@ -3,9 +3,9 @@ include $(top_srcdir)/modules.am
 SUBDIRS = \
 	.
 
-noinst_HEADERS = ipreasm.h socket_pcap.h localapi.h tcpreasm.h
+noinst_HEADERS = ipreasm.h socket_pcap.h localapi.h tcpreasm.h sctp_support.h
 #
-socket_pcap_la_SOURCES = socket_pcap.c ipreasm.c localapi.c tcpreasm.c
+socket_pcap_la_SOURCES = socket_pcap.c ipreasm.c localapi.c tcpreasm.c sctp_support.c
 socket_pcap_la_CFLAGS = -Wall ${MODULE_CFLAGS} ${LUA_CFLAGS}
 socket_pcap_la_LDFLAGS = -module -avoid-version
 socket_pcap_la_LIBADD = ${PTHREAD_LIBS} ${EXPAT_LIBS} ${PCAP_LIBS} ${LUA_LIBS}

--- a/src/modules/socket/pcap/sctp_support.c
+++ b/src/modules/socket/pcap/sctp_support.c
@@ -1,0 +1,70 @@
+/*
+ * $Id$
+ *
+ *  captagent - Homer capture agent. Modular
+ *  Duplicate SIP messages in Homer Encapulate Protocol [HEP] [ipv6 version]
+ *
+ *  Author: Holger Hans Peter Freyther <help@moiji-mobile.com>
+ *  (C) Homer Project 2016 (http://www.sipcapture.org)
+ *
+ * Homer capture agent is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version
+ *
+ * Homer capture agent is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+*/
+
+#include "sctp_support.h"
+
+
+int sctp_parse_common(msg_t *_msg, const uint8_t *data, size_t len)
+{
+	struct sctp_common_hdr *sctp_hdr;
+
+	/* not enough space for the header */
+	if (len < sizeof(*sctp_hdr))
+		return -1;
+
+	sctp_hdr = (struct sctp_common_hdr *) data;
+	_msg->rcinfo.src_port = ntohs(sctp_hdr->source);
+	_msg->rcinfo.dst_port = ntohs(sctp_hdr->dest);
+	return sizeof(*sctp_hdr);;
+}
+
+int sctp_parse_chunk(msg_t *_msg, const uint8_t *data, size_t len, bool *send_data)
+{
+	struct sctp_chunk_data_hdr *dhdr;
+	uint16_t chunk_len;
+
+	*send_data = false;
+	if (len < sizeof(struct sctp_chunk_hdr))
+		return -1;
+
+	/* length smaller than the header */
+	dhdr = (struct sctp_chunk_data_hdr *) data;
+	chunk_len = ntohs(dhdr->len);
+	if (chunk_len < sizeof(*dhdr))
+		return -2;
+
+	if (chunk_len > len)
+		return -3;
+
+	if (dhdr->type != SCTP_CHUNK_DATA)
+		return chunk_len;
+
+	/* check for additional data */
+	if (len < sizeof(*dhdr))
+		return -4;
+	*send_data = true;
+	_msg->sctp_ppid = ntohl(dhdr->ppid);
+	return chunk_len;
+}

--- a/src/modules/socket/pcap/sctp_support.h
+++ b/src/modules/socket/pcap/sctp_support.h
@@ -1,0 +1,76 @@
+/*
+ * $Id$
+ *
+ *  captagent - Homer capture agent. Modular
+ *  Duplicate SIP messages in Homer Encapulate Protocol [HEP] [ipv6 version]
+ *
+ *  Author: Holger Hans Peter Freyther <help@moiji-mobile.com>
+ *  (C) Homer Project 2016 (http://www.sipcapture.org)
+ *
+ * Homer capture agent is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version
+ *
+ * Homer capture agent is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <captagent/api.h>
+#include <captagent/structure.h>
+
+
+enum sctp_chunk_type {
+	SCTP_CHUNK_DATA,
+	SCTP_CHUNK_INIT,
+	SCTP_CHUNK_INIT_ACK,
+	SCTP_CHUNK_SACK,
+	/* Right now only _DATA matters */
+};
+
+struct sctp_common_hdr {
+	uint16_t	source;
+	uint16_t	dest;
+	uint32_t	ver_tag;
+	uint32_t	checksum;
+	uint8_t		data[0];
+} __attribute__((packed));
+
+struct sctp_chunk_hdr {
+	uint8_t		type;
+	uint8_t		flags;
+	uint16_t	len;
+	uint8_t		data[0];
+} __attribute__((packed));
+
+struct sctp_chunk_data_hdr {
+	/* hdr */
+	uint8_t		type;
+	uint8_t		reserved:5,
+			unordered:1,
+			beginning:1,
+			ending: 1;
+	uint16_t	len;
+
+	/* chunk types */
+	uint32_t		tsn;
+	uint16_t		stream_id;
+	uint16_t		seqno;
+	uint32_t		ppid;
+	uint8_t			data[0];
+} __attribute__((packed));
+
+int sctp_parse_common(msg_t *msg, const uint8_t *data, size_t len);
+int sctp_parse_chunk(msg_t *msg, const uint8_t *data, size_t len, bool *send_data);


### PR DESCRIPTION
Add initial support for SCTP and parsing SCTP data chunks. It has
been "verified" with a single SCTP packet containing exactly one
chunk. The code does not support fragmentation of data chunks, the
input validation might not be enough. I didn't understand the
frag_offset calculation (as once we have the SCTP header all IP
offsets are already applied?).

In contrast to TCP and UDP a single frame can contain multiple
chunks and these are dispatched one after another. The counters
are for sctp frames. In general "full_packet" as an option does
not make sense and the hdrlen has not been set. It might require
more architecture changes to move forward. The code also does not
attempt to identify retransmits of a data chunk.

Extend the msg structure to transport the ppid which will allow
to parse M2UA in the next step.

Manaually tested with:

$ ./src/captagent -f ./conf/captagent.xml -n -D ../../single_isup_msg.pcap  -c