### PR TITLE
Fix: 802.1Q VLAN header accounted for twice in packet length

### DIFF
--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -208,8 +208,8 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
 	if (profile_socket[loc_index].reasm == 1 && reasm[loc_index] != NULL) {
 		unsigned new_len;
 
-		u_char *new_p = malloc(len - link_offset - hdr_offset;
-		memcpy(new_p, ip4_pkt, len - link_offset - hdr_offset;
+		u_char *new_p = malloc(len - link_offset - hdr_offset);
+		memcpy(new_p, ip4_pkt, len - link_offset - hdr_offset);
 
 		pack = reasm_ip_next(reasm[loc_index], new_p, len - link_offset - hdr_offset,
 				(reasm_time_t) 1000000UL * pkthdr->ts.tv_sec + pkthdr->ts.tv_usec, &new_len);

--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -180,7 +180,7 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
         struct ethhdr *eth = (struct ethhdr *)packet;
         struct run_act_ctx ctx;                
         
-        struct ip      *ip4_pkt = (struct ip *)    (packet + link_offset + hdr_offset);
+        struct ip      *ip4_pkt = (struct ip *)    (packet + link_offset + hdr_offset + ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4: 0) );
 #if USE_IPv6
         struct ip6_hdr *ip6_pkt = (struct ip6_hdr*)(packet + link_offset + hdr_offset + ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4: 0) );
 #endif

--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -180,9 +180,9 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
         struct ethhdr *eth = (struct ethhdr *)packet;
         struct run_act_ctx ctx;                
         
-        struct ip      *ip4_pkt = (struct ip *)    (packet + link_offset + hdr_offset + ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4: 0) );
+        struct ip      *ip4_pkt = (struct ip *)    (packet + link_offset + hdr_offset);
 #if USE_IPv6
-        struct ip6_hdr *ip6_pkt = (struct ip6_hdr*)(packet + link_offset + hdr_offset + ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4: 0) );
+        struct ip6_hdr *ip6_pkt = (struct ip6_hdr*)(packet + link_offset + hdr_offset);
 #endif
 
 	uint8_t loc_index = (uint8_t) *useless;
@@ -208,15 +208,15 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
 	if (profile_socket[loc_index].reasm == 1 && reasm[loc_index] != NULL) {
 		unsigned new_len;
 
-		u_char *new_p = malloc(len - link_offset - hdr_offset - ((ntohs((uint16_t) *(packet + 12)) == 0x8100) ? 4 : 0));
-		memcpy(new_p, ip4_pkt, len - link_offset - hdr_offset - ((ntohs((uint16_t) *(packet + 12)) == 0x8100) ? 4 : 0));
+		u_char *new_p = malloc(len - link_offset - hdr_offset;
+		memcpy(new_p, ip4_pkt, len - link_offset - hdr_offset;
 
-		pack = reasm_ip_next(reasm[loc_index], new_p, len - link_offset - hdr_offset - ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4:0),
+		pack = reasm_ip_next(reasm[loc_index], new_p, len - link_offset - hdr_offset,
 				(reasm_time_t) 1000000UL * pkthdr->ts.tv_sec + pkthdr->ts.tv_usec, &new_len);
 
 		if (pack == NULL) return;
 
-		len = new_len + link_offset + hdr_offset + ((ntohs((uint16_t) *(packet + 12)) == 0x8100) ? 4 : 0);
+		len = new_len + link_offset + hdr_offset;
 		pkthdr->len = new_len;
 		pkthdr->caplen = new_len;
 
@@ -1202,7 +1202,7 @@ void proccess_packet(msg_t *_m, struct pcap_pkthdr *pkthdr, u_char *packet) {
         
         struct ip      *ip4_pkt = (struct ip *)    (packet + link_offset + hdr_offset);
 #if USE_IPv6
-        struct ip6_hdr *ip6_pkt = (struct ip6_hdr*)(packet + link_offset + hdr_offset + ((ntohs((uint16_t)*(packet + 12)) == 0x8100)? 4: 0) );
+        struct ip6_hdr *ip6_pkt = (struct ip6_hdr*)(packet + link_offset + hdr_offset);
 #endif
 
 	uint32_t ip_ver;


### PR DESCRIPTION
Appears that the 802.1Q header was being allowed for manually in malloc, memcpy, reasm_ip_next and in calculating len, when it had already been allowed for in hdr_offset variable.

This appears to have been responsible for https://github.com/sipcapture/captagent/issues/96 which is fixed on my system by this patch

**Note: I have not tested in a VLAN untagged environment or with IPv6**