### PR TITLE
Added: uthash.h

### DIFF
--- a/src/modules/socket/pcap/Makefile.am
+++ b/src/modules/socket/pcap/Makefile.am
@@ -3,7 +3,7 @@ include $(top_srcdir)/modules.am
 SUBDIRS = \
 	.
 
-noinst_HEADERS = ipreasm.h socket_pcap.h localapi.h tcpreasm.h sctp_support.h
+noinst_HEADERS = ipreasm.h socket_pcap.h localapi.h tcpreasm.h sctp_support.h uthash.h
 #
 socket_pcap_la_SOURCES = socket_pcap.c ipreasm.c localapi.c tcpreasm.c sctp_support.c
 socket_pcap_la_CFLAGS = -Wall ${MODULE_CFLAGS} ${LUA_CFLAGS}


### PR DESCRIPTION
Any build from "make dist" produced tarball fails without this fix.