### PR TITLE
Fix enabling of Packet reassembly

### DIFF
--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -9,7 +9,7 @@ export DH_OPTIONS
 
 build:
 	autoreconf -if
-	./configure --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+	./configure --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH) --enable-ipv6
 	make
 
 binary-arch:


### PR DESCRIPTION
Previously, en enabled setting of capture_filter option was needed to turn on the reassembly of fragmented packets. Actually it should depend on a filter being set. So the section got rewritten.

Additionally, Debian packages are now built with IPv6 support.

Fixes #78.