### PR TITLE
Define PATH_MAX if not defined

### DIFF
--- a/src/modules/interface/http/civetweb.c
+++ b/src/modules/interface/http/civetweb.c
@@ -101,7 +101,7 @@
 #include <windows.h>
 
 #ifndef PATH_MAX
-#define PATH_MAX MAX_PATH
+#define PATH_MAX 4096
 #endif
 
 #ifndef _IN_PORT_T

--- a/src/modules/interface/http/interface_http.c
+++ b/src/modules/interface/http/interface_http.c
@@ -53,6 +53,10 @@
 #include <json.h>  
 #endif
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #include <captagent/globals.h>
 #include <captagent/api.h>
 #include <captagent/structure.h>


### PR DESCRIPTION
On systems without glibc, as Alpine Linux, you might lack definition of
PATH_MAX.  This patch simply assure that the definition exists, set to
4096 which is the standard, otherwise the code will break,as it is
breaking today:

 http://build.alpinelinux.org/buildlogs/build-edge-ppc64le/testing/captagent/captagent-6.1.0.20-r3.log

It is important to say that MAX_PATH is also not a definition we have on
MUSL systems.