### PR TITLE
fix build errors

### DIFF
--- a/m4/modules_makefiles.m4
+++ b/m4/modules_makefiles.m4
@@ -5,11 +5,13 @@ AC_CONFIG_FILES([
 	src/modules/protocol/ss7/Makefile
 	src/modules/protocol/tcp/Makefile
 	src/modules/protocol/rtcp/Makefile
+	src/modules/protocol/rtcpxr/captureplan/Makefile
+	src/modules/protocol/rtcpxr/Makefile
 	src/modules/protocol/rtcp/captureplan/Makefile
 	src/modules/socket/pcap/Makefile
 	src/modules/socket/raw/Makefile
-	src/modules/socket/rtcpxr/Makefile
-	src/modules/socket/rtcpxr/captureplan/Makefile
+	src/modules/socket/collector/Makefile
+	src/modules/socket/collector/captureplan/Makefile
 	src/modules/socket/tzsp/Makefile
 	src/modules/socket/tzsp/captureplan/Makefile
 	src/modules/transport/hep/Makefile

--- a/src/modules/protocol/rtcp/protocol_rtcp.c
+++ b/src/modules/protocol/rtcp/protocol_rtcp.c
@@ -190,11 +190,6 @@ void free_module_xml_config() {
 
 
 /* modules external API */
-static uint64_t serial_module(void)
-{
-  return module_serial;
-}
-
 
 static int load_module(xml_node *config) {
   xml_node *params, *profile, *settings;

--- a/src/modules/protocol/rtcpxr/Makefile.am
+++ b/src/modules/protocol/rtcpxr/Makefile.am
@@ -6,11 +6,11 @@ SUBDIRS = \
 
 noinst_HEADERS = parser_rtcpxr.h protocol_rtcpxr.h
 #
-protocol_rtcp_la_SOURCES = protocol_rtcpxr.c parser_rtcpxr.c
-protocol_rtcp_la_CFLAGS = -Wall ${MODULE_CFLAGS}
-protocol_rtcp_la_LDFLAGS = -module -avoid-version
-protocol_rtcp_la_LIBADD = ${PTHREAD_LIBS} ${EXPAT_LIBS}
-protocol_rtcp_laconfdir = $(confdir)
-protocol_rtcp_laconf_DATA = $(top_srcdir)/conf/protocol_rtcpxr.xml
+protocol_rtcpxr_la_SOURCES = protocol_rtcpxr.c parser_rtcpxr.c
+protocol_rtcpxr_la_CFLAGS = -Wall ${MODULE_CFLAGS}
+protocol_rtcpxr_la_LDFLAGS = -module -avoid-version
+protocol_rtcpxr_la_LIBADD = ${PTHREAD_LIBS} ${EXPAT_LIBS}
+protocol_rtcpxr_laconfdir = $(confdir)
+protocol_rtcpxr_laconf_DATA = $(top_srcdir)/conf/protocol_rtcpxr.xml
 
 mod_LTLIBRARIES = protocol_rtcpxr.la

--- a/src/modules/protocol/rtcpxr/captureplan/Makefile.am
+++ b/src/modules/protocol/rtcpxr/captureplan/Makefile.am
@@ -3,4 +3,4 @@ include $(top_srcdir)/modules.am
 SUBDIRS = .
 
 capture_planconfdir = $(confdir)/captureplans
-capture_planconf_DATA = $(top_srcdir)/conf/captureplans/rtcpx_capture_plan.cfg
+capture_planconf_DATA = $(top_srcdir)/conf/captureplans/rtcpxr_capture_plan.cfg

--- a/src/modules/protocol/rtcpxr/parser_rtcpxr.c
+++ b/src/modules/protocol/rtcpxr/parser_rtcpxr.c
@@ -26,11 +26,11 @@
 #include <stdio.h>
 #include <captagent/log.h>
 #include <arpa/inet.h>
-#include "parser_rtcp.h"
+#include "parser_rtcpxr.h"
 
 
 // RTCP-XR check version
-int check_rtcpxr_version(const u_char *packet, int size_payload)
+int check_rtcpxr_version(char *packet, int size_payload)
 {
   u_int8_t offset = 0, is_xr = 0;
   

--- a/src/modules/protocol/rtcpxr/parser_rtcpxr.h
+++ b/src/modules/protocol/rtcpxr/parser_rtcpxr.h
@@ -34,6 +34,7 @@
 // Macro to create JSON buffer (fields from RTCP-XR block)
 #define EXTENDED_REPORT_JSON "\"Extended_report_information\":{\"identifier\":%u, \"loss_rate\":%u, \"discard_rate\":%u, \"burst_rate\":%u, \"gap_rate\":%u, \"burst_duration\":%u, \"gap_duration\":%u, \"round_trip_delay\":%u, \"end_sys_delay\":%u, \"signal_lev\":%u, \"noise_lev\":%u, \"RERL\":%u, \"Gmin\":%u, \"R_fact\":%u, \"ext_R_fact\":%u, \"MOS_LQ\":%u, \"MOS_CQ\":%u, \"RX_conf\":[{\"PLC\":%u, \"JB_adapt\":%u, \"JB_rate\":%u}], \"JB_nom\":%u, \"JB_max\":%u, \"JB_abs_max\":%u}"
 
+#define JSON_BUFFER_LEN 5000
 
 typedef enum {
     RTCP_SR   = 200,

--- a/src/modules/protocol/rtcpxr/protocol_rtcpxr.c
+++ b/src/modules/protocol/rtcpxr/protocol_rtcpxr.c
@@ -118,7 +118,7 @@ int w_is_rtcpxr(msg_t *msg)
   switch(ret) {
   case -1:
     {
-      LDERR("Error on parameters (data or length)\n");
+      LERR("Error on parameters (data or length)\n");
       return -1;
     }
   case -2:
@@ -232,8 +232,6 @@ static int load_module(xml_node *config)
 
     profile = xml_get("profile", profile, 1);
 
-    memset(&profile_socket[i], 0, sizeof(profile_socket_t));
-
     if (profile == NULL)
       break;
 
@@ -327,8 +325,8 @@ static int free_profile(unsigned int idx)
   /*free profile chars **/
   if (profile_protocol[idx].name)	 free(profile_protocol[idx].name);
   if (profile_protocol[idx].description) free(profile_protocol[idx].description);
-  if (profile_protocol[idx].serial) free(profile_protocol[idx].serial);
-  
+  if (profile_protocol[idx].ignore) free(profile_protocol[idx].ignore);
+
   return 1;
 }
 
@@ -342,7 +340,7 @@ static int statistic(char *buf, size_t len) {
 
   int ret = 0;
 
-    ret += snprintf(buf+ret, len-ret, "Total received: [%" PRId64 "]\r\n", stats.received_packets_total);
+  ret += snprintf(buf+ret, len-ret, "Total received: [%" PRId64 "]\r\n", stats.received_packets_total);
   ret += snprintf(buf+ret, len-ret, "Parsed packets: [%" PRId64 "]\r\n", stats.parsed_packets);
   ret += snprintf(buf+ret, len-ret, "Total sent: [%" PRId64 "]\r\n", stats.send_packets);
 

--- a/src/modules/protocol/rtcpxr/protocol_rtcpxr.h
+++ b/src/modules/protocol/rtcpxr/protocol_rtcpxr.h
@@ -29,12 +29,21 @@
 #include <captagent/xmlread.h>
 #include "parser_rtcpxr.h"
 
+typedef struct protocol_rtcpxr_stats {
+	uint64_t received_packets_total;
+	uint64_t parsed_packets;
+	uint64_t send_packets;
+} protocol_rtcpxr_stats_t;
+
+static protocol_rtcpxr_stats_t stats;
+
+#define MAX_PROTOCOLS 10
+profile_protocol_t profile_protocol[MAX_PROTOCOLS];
+
 int bind_api(socket_module_api_t* api);
 int reload_config (char *erbuf, int erlen);
 void free_module_xml_config();
 int load_module_xml_config();
-int close_socket(unsigned int loc_idx);
-void on_send(uv_udp_send_t* req, int status);
 
 /** Functions for RTCP-XR **/
 int w_parse_rtcpxr_to_json(msg_t *msg);


### PR DESCRIPTION
m4/modules_makefiles.m4:
  * add modules/protocol/rtcpxr makefiles
  * renamed module socket/{rtcpxr,collector}
modules/protocol/rtcp/protocol_rtcp.c:
  * remove duplicate function
modules/protocol/rtcpxr/Makefile.am:
  * fix duplicate varnames
src/modules/protocol/rtcpxr/captureplan/Makefile.am:
  * fix typo in path to captureplan
src/modules/protocol/rtcpxr/parser_rtcpxr.c:
  * fix typo to header file
  * fix warning about different pointer signedness
src/modules/protocol/rtcpxr/parser_rtcpxr.h:
  * fix missing macro
src/modules/protocol/rtcpxr/protocol_rtcpxr.c:
  * fix typo in logger macro
  * remove undefined variable
  * fix free'ing int
src/modules/protocol/rtcpxr/protocol_rtcpxr.h
  * add missing stats struct (only free'd, besides unused)
  * add missing struct for protocol profiles (besides different profiles
    aren't supported)
  * remove unimplemented functions