### PR TITLE
Random fixes, primarily to get socket_pcap working

### DIFF
--- a/src/modules/database/hash/captarray.c
+++ b/src/modules/database/hash/captarray.c
@@ -81,7 +81,7 @@ int gather_data_run()
 	timer_queue_t *pos, *lpos;
 	unsigned int mycount = 0;
 
-	while (timer_loop_stop) {
+	while (!timer_loop_stop) {
 
 		list_for_each_entry_safe(pos, lpos, &g_queue_head, node)
 		{

--- a/src/modules/database/hash/database_hash.c
+++ b/src/modules/database/hash/database_hash.c
@@ -572,7 +572,7 @@ static int unload_module(void) {
 	unsigned int i = 0;
 
 	LNOTICE("unloaded module %s", module_name);
-	timer_loop_stop = 0;
+	timer_loop_stop = 1;
 
 	for (i = 0; i < profile_size; i++) {
 		free_profile(i);

--- a/src/modules/protocol/rtcp/protocol_rtcp.c
+++ b/src/modules/protocol/rtcp/protocol_rtcp.c
@@ -125,7 +125,7 @@ int w_parse_rtcp_to_json(msg_t *_m)
 
 int w_is_rtcp (msg_t *msg) {
 
-  printf("IS RTCP\n\n");
+  LDEBUG("IS RTCP\n");
   return check_rtcp_version (msg->data, msg->len);
 }
 

--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -183,7 +183,7 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
     if (tmp_ip_proto == GRE_PROTO) {
       memcpy(&tmp_ip_len, (packet + ETHHDR_SIZE), 1);
       tmp_ip_len = (tmp_ip_len & IPLEN_MASK) * 4; // LSB 4 bits: length in 32-bit words
-      //printf("ip.proto: %d, ip header len: %d\n", tmp_ip_proto, tmp_ip_len);
+      //printf("ip.proto: %u, ip header len: %u\n", tmp_ip_proto, tmp_ip_len);
       erspan_offset = ETHHDR_SIZE + tmp_ip_len + GREHDR_SIZE; // Ethernet + IP + GRE
       pkthdr->len -= erspan_offset;
       pkthdr->caplen -= erspan_offset;
@@ -364,7 +364,7 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
       if((tcp_pkt->th_flags & TH_PUSH)) psh = 1;
 
                                         
-      if(debug_socket_pcap_enable) LDEBUG("DEFRAG TCP process: LEN:[%d], ACK:[%d], PSH[%d]\n", len, (tcp_pkt->th_flags & TH_ACK), psh);
+      if(debug_socket_pcap_enable) LDEBUG("DEFRAG TCP process: LEN:[%u], ACK:[%u], PSH[%u]\n", len, (tcp_pkt->th_flags & TH_ACK), psh);
                         
       datatcp = tcpreasm_ip_next_tcp(tcpreasm[loc_index], new_p_2, len , (tcpreasm_time_t) 1000000UL * pkthdr->ts.tv_sec + pkthdr->ts.tv_usec, &new_len, &ip4_pkt->ip_src, &ip4_pkt->ip_dst, ntohs(tcp_pkt->th_sport), ntohs(tcp_pkt->th_dport), psh);
 
@@ -373,7 +373,7 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
       len = new_len;
                         
       if(debug_socket_pcap_enable)
-	LDEBUG("COMPLETE TCP DEFRAG: LEN[%d], PACKET:[%s]\n", len, datatcp);
+	LDEBUG("COMPLETE TCP DEFRAG: LEN[%u], PACKET:[%s]\n", len, datatcp);
                         
 
       if(!profile_socket[profile_size].full_packet) {
@@ -612,12 +612,12 @@ int init_socket(unsigned int loc_idx) {
 		};
 		
 		if (pcap_set_snaplen(sniffer_proto[loc_idx], profile_socket[loc_idx].snap_len) == -1) {
-			LERR("Failed to set snap_len [%d], \"%s\": %s", profile_socket[loc_idx].snap_len, (char *) profile_socket[loc_idx].device, pcap_geterr(sniffer_proto[loc_idx]));
+			LERR("Failed to set snap_len [%u], \"%s\": %s", profile_socket[loc_idx].snap_len, (char *) profile_socket[loc_idx].device, pcap_geterr(sniffer_proto[loc_idx]));
 			return -1;						
 		};
 		
 		if (pcap_set_buffer_size(sniffer_proto[loc_idx], buffer_size) == -1) {
-			LERR("Failed to set buffer_size [%d] \"%s\": %s", buffer_size,  (char *) profile_socket[loc_idx].device, pcap_geterr(sniffer_proto[loc_idx]));
+			LERR("Failed to set buffer_size [%u] \"%s\": %s", buffer_size,  (char *) profile_socket[loc_idx].device, pcap_geterr(sniffer_proto[loc_idx]));
 			return -1;									
 		};
 		
@@ -704,7 +704,7 @@ int set_raw_filter(unsigned int loc_idx, char *filter) {
         //struct pcap_t *aa;
         int fd = -1;
                 
-        LERR("APPLY FILTER [%d]\n", loc_idx);        
+        LERR("APPLY FILTER [%u]\n", loc_idx);
         if(loc_idx >= MAX_SOCKETS || sniffer_proto[loc_idx] == NULL) return 0;         
 
         fd = pcap_get_selectable_fd(sniffer_proto[loc_idx]);
@@ -781,7 +781,7 @@ void* proto_collect(void *arg) {
 		exit(-1);
 	}
 
-	LDEBUG("Link offset interface type [%u] [%d] [%d]", dl, dl, link_offset);
+	LDEBUG("Link offset interface type [%u] [%d] [%u]", dl, dl, link_offset);
 
 	while(1) {
 		ret = pcap_loop(sniffer_proto[loc_idx], 0, (pcap_handler) callback_proto, (u_char *) &loc_idx);

--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -88,6 +88,7 @@ char *module_description;
 int debug_socket_pcap_enable = 0;
 
 static socket_pcap_stats_t stats;
+static socket_pcap_user_data_t user_data[MAX_SOCKETS];
 
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_t call_thread[MAX_SOCKETS];
@@ -643,14 +644,14 @@ int init_socket(unsigned int loc_idx) {
 	{
 		len += snprintf(filter_expr+len, sizeof(filter_expr)-len, "(%s)", profile_socket[loc_idx].filter);
 
-		if(ipv4fragments || ipv6fragments)
+		if(user_data[loc_idx].ipv4fragments || user_data[loc_idx].ipv6fragments)
 		{
-			if (ipv4fragments)
+			if (user_data[loc_idx].ipv4fragments)
 			{
 				LDEBUG("Reassembling of IPv4 packets is enabled, adding '%s' to filter", BPF_DEFRAGMENTION_FILTER_IPV4);
 				len += snprintf(filter_expr+len, sizeof(filter_expr), " or %s", BPF_DEFRAGMENTION_FILTER_IPV4);
 			}
-			if (ipv6fragments)
+			if (user_data[loc_idx].ipv6fragments)
 			{
 				LDEBUG("Reassembling of IPv6 packets is enabled, adding '%s' to filter", BPF_DEFRAGMENTION_FILTER_IPV6);
 				len += snprintf(filter_expr+len, sizeof(filter_expr), " or %s", BPF_DEFRAGMENTION_FILTER_IPV6);
@@ -915,6 +916,7 @@ static int load_module(xml_node *config) {
 		}
 
 		memset(&profile_socket[profile_size], 0, sizeof(profile_socket_t));
+		memset(&user_data[profile_size], 0, sizeof(socket_pcap_user_data_t));
 
 		/* set values */
 		profile_socket[profile_size].name = strdup(profile->attr[1]);
@@ -971,9 +973,9 @@ static int load_module(xml_node *config) {
 					else if (!strncmp(key, "reasm", 5) && !strncmp(value, "true", 4))
 						profile_socket[profile_size].reasm |= REASM_UDP;
                                         else if (!strncmp(key, "ipv4fragments", 13) && !strncmp(value, "true", 4))
-						ipv4fragments = 1;
+						user_data[profile_size].ipv4fragments = 1;
                                         else if (!strncmp(key, "ipv6fragments", 13) && !strncmp(value, "true", 4))
-						ipv6fragments = 1;
+						user_data[profile_size].ipv6fragments = 1;
                                         else if(!strncmp(key, "tcpdefrag", 9) && !strncmp(value, "true", 4))
                                                 profile_socket[profile_size].reasm |= REASM_TCP;
 					else if (!strncmp(key, "ring-buffer", 11))					        

--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -252,7 +252,7 @@ void callback_proto(u_char *useless, struct pcap_pkthdr *pkthdr, u_char *packet)
   /* stats */
   stats.received_packets_total++;
 
-  if (profile_socket[loc_index].reasm == 1 && reasm[loc_index] != NULL) {
+  if (profile_socket[loc_index].reasm && reasm[loc_index] != NULL) {
     unsigned new_len;
 
     u_char *new_p = malloc(len - link_offset - hdr_offset);
@@ -969,13 +969,13 @@ static int load_module(xml_node *config) {
 					if (!usefile && !strncmp(key, "dev", 3))
 						profile_socket[profile_size].device = strdup(value);
 					else if (!strncmp(key, "reasm", 5) && !strncmp(value, "true", 4))
-						profile_socket[profile_size].reasm = +1;
+						profile_socket[profile_size].reasm |= REASM_UDP;
                                         else if (!strncmp(key, "ipv4fragments", 13) && !strncmp(value, "true", 4))
 						ipv4fragments = 1;
                                         else if (!strncmp(key, "ipv6fragments", 13) && !strncmp(value, "true", 4))
 						ipv6fragments = 1;
                                         else if(!strncmp(key, "tcpdefrag", 9) && !strncmp(value, "true", 4))
-                                                profile_socket[profile_size].reasm +=2;                                                    						
+                                                profile_socket[profile_size].reasm |= REASM_TCP;
 					else if (!strncmp(key, "ring-buffer", 11))					        
 						profile_socket[profile_size].ring_buffer = atoi(value);		
 					else if (!strncmp(key, "full-packet",11) && !strncmp(value, "true", 4))					        
@@ -1034,14 +1034,14 @@ static int load_module(xml_node *config) {
 		}
 
 		 /* REASM */
-                if (profile_socket[i].reasm == 1 || profile_socket[i].reasm == 3) {
+                if (profile_socket[i].reasm & REASM_UDP) {
                         reasm[i] = reasm_ip_new();
                         reasm_ip_set_timeout(reasm[i], 30000000);
                 }
                 else reasm[i] = NULL;
 
                 /* TCPREASM */
-                if (profile_socket[i].reasm == 2 || profile_socket[i].reasm == 3) {
+                if (profile_socket[i].reasm & REASM_TCP) {
                         tcpreasm[i] = tcpreasm_ip_new ();
                         tcpreasm_ip_set_timeout(tcpreasm[i], 30000000);
                 }

--- a/src/modules/socket/pcap/socket_pcap.h
+++ b/src/modules/socket/pcap/socket_pcap.h
@@ -110,6 +110,9 @@ int dump_proto_packet(struct pcap_pkthdr *, u_char *, uint8_t, char *, uint32_t,
 /*IPv6 filter*/
 #define BPF_DEFRAGMENTION_FILTER_IPV6 "(ip6[6]=44 and (ip6[42:2] & 0xfff8 != 0))"
 
+#define REASM_UDP (1<<0)
+#define REASM_TCP (1<<1)
+
 #define TZSP_TYPE_RECEIVED_TAG_LIST 0
 #define TZSP_TYPE_PACKET_FOR_TRANSMIT 1
 #define TZSP_TYPE_RESERVED 2

--- a/src/modules/socket/pcap/socket_pcap.h
+++ b/src/modules/socket/pcap/socket_pcap.h
@@ -106,7 +106,7 @@ int dump_proto_packet(struct pcap_pkthdr *, u_char *, uint8_t, char *, uint32_t,
 
 
 /*IPv4 filter*/
-#define BPF_DEFRAGMENTION_FILTER_IPV4 "(ip[6:2] & 0x3fff != 0)"
+#define BPF_DEFRAGMENTION_FILTER_IPV4 "(ip[6:2] & 0x1fff != 0)"
 /*IPv6 filter*/
 #define BPF_DEFRAGMENTION_FILTER_IPV6 "(ip6[6]=44 and (ip6[42:2] & 0xfff8 != 0))"
 

--- a/src/modules/socket/pcap/socket_pcap.h
+++ b/src/modules/socket/pcap/socket_pcap.h
@@ -34,9 +34,6 @@ extern int handler(int value);
 extern char *global_config_path;
 extern char *global_scripts_path;
 
-int ipv4fragments=0;
-int ipv6fragments=0;
-
 /* Ethernet type in case of vlan or mpls header */
 #define VLAN            0x8100
 #define MPLS_UNI        0x8847
@@ -84,6 +81,13 @@ typedef struct socket_pcap_stats {
 	uint64_t received_sctp_packets;
 	uint64_t send_packets;
 } socket_pcap_stats_t;
+
+typedef struct socket_pcap_user_data {
+	int ipv4fragments;
+	int ipv6fragments;
+
+} socket_pcap_user_data_t;
+
 
 extern FILE* yyin;
 extern int yyparse();

--- a/src/modules/socket/pcap/tcpreasm.c
+++ b/src/modules/socket/pcap/tcpreasm.c
@@ -24,6 +24,8 @@
 #include <netinet/ip6.h>
 #endif /* USE_IPv6 */
 
+#include <captagent/log.h>
+
 extern int debug_socket_pcap_enable;
 
 #include "tcpreasm.h"
@@ -247,7 +249,7 @@ tcpreasm_ip_next_tcp (struct tcpreasm_ip *tcpreasm, unsigned char *packet, unsig
                 
         if(debug_socket_pcap_enable) {
         
-        	printf("\nTCPREASM: Proto [%d], Hash:[%d] SPORT: [%d], DPORT: [%d]\n", proto, hash, sport, dport);
+                LDEBUG("TCPREASM: Proto [%d], Hash:[%d] SPORT: [%d], DPORT: [%d]\n", proto, hash, sport, dport);
         }
         
 	hash %= REASM_IP_HASH_SIZE;
@@ -259,14 +261,14 @@ tcpreasm_ip_next_tcp (struct tcpreasm_ip *tcpreasm, unsigned char *packet, unsig
 	/* no buffer, go out */
 	if(psh == 1 && entry == NULL) {
 		free(frag);
-		if(debug_socket_pcap_enable) printf("RETURN PACKET BACK\n");
+		if(debug_socket_pcap_enable) LDEBUG("RETURN PACKET BACK\n");
 		*output_len = len;
 		return packet;
 	}		
 
 	if (entry == NULL) {
 	
-		if(debug_socket_pcap_enable) printf("EMPTY ENTRY\n");
+		if(debug_socket_pcap_enable) LDEBUG("EMPTY ENTRY\n");
         			
 		entry = malloc (sizeof (*entry));
 		if (entry == NULL) {
@@ -339,8 +341,8 @@ tcpreasm_ip_next_tcp (struct tcpreasm_ip *tcpreasm, unsigned char *packet, unsig
 	
 	unsigned char *r = assemble_tcp (entry, output_len);
 
-	//printf("TCP REASSEM: [%d]\n", *output_len);
-	//printf("MESSAGE: [%s]\n", r);
+	//LDEBUG("TCP REASSEM: [%d]\n", *output_len);
+	//LDEBUG("MESSAGE: [%s]\n", r);
 	
 	drop_entry (tcpreasm, entry);
 	return r;
@@ -419,7 +421,7 @@ assemble_tcp (struct tcpreasm_ip_entry *entry, unsigned *output_len)
 	unsigned char *p = malloc (entry->len + offset0);
 	unsigned tlen = 0;
 	
-	//printf("TOTAL LEN: %d\n", entry->len);
+	//LDEBUG("TOTAL LEN: %d\n", entry->len);
 	
 	if (p == NULL)
 		return NULL;

--- a/src/modules/socket/pcap/tcpreasm.c
+++ b/src/modules/socket/pcap/tcpreasm.c
@@ -249,7 +249,7 @@ tcpreasm_ip_next_tcp (struct tcpreasm_ip *tcpreasm, unsigned char *packet, unsig
                 
         if(debug_socket_pcap_enable) {
         
-                LDEBUG("TCPREASM: Proto [%d], Hash:[%d] SPORT: [%d], DPORT: [%d]\n", proto, hash, sport, dport);
+                LDEBUG("TCPREASM: Proto [%d], Hash:[%u] SPORT: [%u], DPORT: [%u]\n", proto, hash, sport, dport);
         }
         
 	hash %= REASM_IP_HASH_SIZE;
@@ -341,7 +341,7 @@ tcpreasm_ip_next_tcp (struct tcpreasm_ip *tcpreasm, unsigned char *packet, unsig
 	
 	unsigned char *r = assemble_tcp (entry, output_len);
 
-	//LDEBUG("TCP REASSEM: [%d]\n", *output_len);
+	//LDEBUG("TCP REASSEM: [%u]\n", *output_len);
 	//LDEBUG("MESSAGE: [%s]\n", r);
 	
 	drop_entry (tcpreasm, entry);
@@ -421,7 +421,7 @@ assemble_tcp (struct tcpreasm_ip_entry *entry, unsigned *output_len)
 	unsigned char *p = malloc (entry->len + offset0);
 	unsigned tlen = 0;
 	
-	//LDEBUG("TOTAL LEN: %d\n", entry->len);
+	//LDEBUG("TOTAL LEN: %u\n", entry->len);
 	
 	if (p == NULL)
 		return NULL;


### PR DESCRIPTION
This PR primarily fixes bugs in socket_pcap. Details are in the individual commits.

The last patch fixes a bug with inverse logic causing the timer not to run.

Furthermore, this patchset reduces verbosity by moving printf's to LDEBUG.

These fixes have no corresponding issue filed.