### PR TITLE
Basic CI testing of Captagent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ install:
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
 script:
-  - export IP=$(ifconfig eth0 | grep -oP 'inet addr:\K\S+') && echo "eth0 address: $IP"
+  - ip -o -4 a | awk '$2 == "eth0" { gsub(/\/.*/, "", $4); print $4 }'
+  - ip -o -4 a | awk '$2 == "lo" { gsub(/\/.*/, "", $4); print $4 }'
   - ./build.sh
   - ./configure ${CONFIGURE}
-  - sudo sed -i 's/any/eth0/g' conf/socket_pcap.xml
+  - sudo sed -i 's/any/lo/g' conf/socket_pcap.xml
   - make
   - sudo make install
   - ./src/captagent -h
   - ./src/captagent -v
-  - sudo sed -i 's/127.0.0.1/$IP/g' test/hep.js
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
 script:
   - ./build.sh
   - ./configure ${CONFIGURE}
+  - sudo sed -i 's/any/lo/g' conf/socket_pcap.xml
   - make
   - sudo make install
-  - sudo sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
   - ./src/captagent -h
   - ./src/captagent -v
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ addons:
       - net-tools
 compiler:
   - gcc
-
+before_install:
+  - sudo apt-get install -y libpcap0.8 -qq
+  - sudo ln -s /usr/lib/x86_64-linux-gnu/libpcap.so.1.5.3 /usr/lib/x86_64-linux-gnu/libpcap.so
+  - sudo ls -al /usr/lib/x86_64-linux-gnu/libpcap.*
 install: 
   - sudo -E apt-add-repository -y ppa:linuxjedi/ppa
   - sudo apt-get update || true
@@ -28,7 +31,6 @@ install:
   - sudo apt-get install -y libpcap-dev libexpat-dev libjson0-dev bison flex libtool autoconf automake autogen libuv-dev libssl-dev libgcrypt20 libgcrypt20-dev 
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
-
 script:
   - ./build.sh
   - ./configure ${CONFIGURE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - sudo npm i -g npm
 
 script:
+  - sudo sed -i 's/any/lo/g' ./conf/socket_pcap.xml
   - ./build.sh
   - ./configure ${CONFIGURE}
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ install:
 script:
   - ./build.sh
   - ./configure ${CONFIGURE}
-# - sudo sed -i 's/any/lo/g' conf/socket_pcap.xml
   - make
   - sudo make install
   - ./src/captagent -h

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ matrix:
         - CONFIGURE="--enable-ssl"      
 
 language: c
-
+addons:
+  apt:
+    packages:
+      - net-tools
 compiler:
   - gcc
 
@@ -32,4 +35,5 @@ script:
   - make
   - ./src/captagent -h
   - ./src/captagent -v
+  - sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,10 @@ install:
   - sudo npm i -g npm
 
 script:
-  - sudo sed -i 's/any/lo/g' conf/socket_pcap.xml
   - ./build.sh
   - ./configure ${CONFIGURE}
   - make
   - sudo make install
   - sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' ./src/captagent || echo "Setcap failed"
-  - sudo chmod u+s ./src/captagent  || echo "chmod u+s failed"
   - ./src/captagent -v
   - cd test && npm install && sudo -s npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
   - make
   - ./src/captagent -h
   - ./src/captagent -v
-  - cd test && npm install -g mocha && npm install && sudo npm test
+  - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - ./build.sh
   - ./configure ${CONFIGURE}
   - make
-  - make install
+  - sudo make install
   - ./src/captagent -h
   - ./src/captagent -v
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ before_install:
 install: 
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
-  - sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
 script:
   - ./build.sh
   - ./configure ${CONFIGURE}
   - make
   - sudo make install
+  - sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
   - ./src/captagent -h
   - ./src/captagent -v
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,11 @@ addons:
 compiler:
   - gcc
 before_install:
-  - sudo apt-get install -y libpcap0.8 -qq
-  - sudo ln -s /usr/lib/x86_64-linux-gnu/libpcap.so.1.5.3 /usr/lib/x86_64-linux-gnu/libpcap.so
-  - sudo ls -al /usr/lib/x86_64-linux-gnu/libpcap.*
-install: 
   - sudo -E apt-add-repository -y ppa:linuxjedi/ppa
   - sudo apt-get update || true
   - sudo apt-get install -y build-essential
   - sudo apt-get install -y libpcap-dev libexpat-dev libjson0-dev bison flex libtool autoconf automake autogen libuv-dev libssl-dev libgcrypt20 libgcrypt20-dev 
+install: 
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 install: 
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
+  - sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
 script:
   - ./build.sh
   - ./configure ${CONFIGURE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - ./configure ${CONFIGURE}
   - make
   - sudo make install
-  - sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
+  - sudo sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
   - ./src/captagent -h
   - ./src/captagent -v
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ compiler:
 install: 
   - sudo -E apt-add-repository -y ppa:linuxjedi/ppa
   - sudo apt-get update || true
-  - sudo apt-get install build-essential
-  - sudo apt-get install libpcap-dev libexpat-dev libjson0-dev bison flex libtool autoconf automake autogen libuv-dev libssl-dev libgcrypt20 libgcrypt20-dev 
+  - sudo apt-get install -y build-essential
+  - sudo apt-get install -y libpcap-dev libexpat-dev libjson0-dev bison flex libtool autoconf automake autogen libuv-dev libssl-dev libgcrypt20 libgcrypt20-dev 
+  - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+  - sudo apt-get install -y nodejs
+  - sudo npm install -r mocha
 
 script:
   - ./build.sh
@@ -30,3 +33,4 @@ script:
   - make
   - ./src/captagent -h
   - ./src/captagent -v
+  - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
   - sudo apt-get install -y libpcap-dev libexpat-dev libjson0-dev bison flex libtool autoconf automake autogen libuv-dev libssl-dev libgcrypt20 libgcrypt20-dev 
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
-  - sudo npm install -r mocha
 
 script:
   - ./build.sh
@@ -33,4 +32,4 @@ script:
   - make
   - ./src/captagent -h
   - ./src/captagent -v
-  - cd test && npm install && sudo npm test
+  - cd test && npm install -g mocha && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - ./build.sh
   - ./configure ${CONFIGURE}
   - make
+  - make install
   - ./src/captagent -h
   - ./src/captagent -v
-  - sed -i 's/any/lo/g' /usr/local/captagent/etc/captagent/socket_pcap.xml
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,13 @@ install:
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
 script:
+  - IP=$(ifconfig eth0 | grep -oP 'inet addr:\K\S+') && echo "eth0 address: $IP"
   - ./build.sh
   - ./configure ${CONFIGURE}
-  - sudo sed -i 's/any/lo/g' conf/socket_pcap.xml
+  - sudo sed -i 's/any/eth0/g' conf/socket_pcap.xml
   - make
   - sudo make install
   - ./src/captagent -h
   - ./src/captagent -v
+  - sudo sed -i 's/127.0.0.1/$IP/g' test/hep.js
   - cd test && npm install && sudo npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,19 @@ before_install:
   - sudo apt-get update || true
   - sudo apt-get install -y build-essential
   - sudo apt-get install -y libpcap-dev libexpat-dev libjson0-dev bison flex libtool autoconf automake autogen libuv-dev libssl-dev libgcrypt20 libgcrypt20-dev 
+  - ip -o -4 a | awk '$2 == "eth0" { gsub(/\/.*/, "", $4); print $4 }' > /tmp/pubip
+  - ip -o -4 a | awk '$2 == "lo" { gsub(/\/.*/, "", $4); print $4 }' > /tmp/localip
 install: 
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
+  - sudo npm i -g npm
 script:
-  - ip -o -4 a | awk '$2 == "eth0" { gsub(/\/.*/, "", $4); print $4 }'
-  - ip -o -4 a | awk '$2 == "lo" { gsub(/\/.*/, "", $4); print $4 }'
   - ./build.sh
   - ./configure ${CONFIGURE}
-  - sudo sed -i 's/any/lo/g' conf/socket_pcap.xml
+# - sudo sed -i 's/any/lo/g' conf/socket_pcap.xml
   - make
   - sudo make install
   - ./src/captagent -h
   - ./src/captagent -v
   - cd test && npm install && sudo npm test
+  - echo "IP: `cat /tmp/pubip`"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
   - sudo apt-get install -y nodejs
 script:
-  - IP=$(ifconfig eth0 | grep -oP 'inet addr:\K\S+') && echo "eth0 address: $IP"
+  - export IP=$(ifconfig eth0 | grep -oP 'inet addr:\K\S+') && echo "eth0 address: $IP"
   - ./build.sh
   - ./configure ${CONFIGURE}
   - sudo sed -i 's/any/eth0/g' conf/socket_pcap.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
   - ./configure ${CONFIGURE}
   - make
   - sudo make install
-  - sudo setcap cap_net_raw=ep src/captagent || echo "Setcap failed"
+  - sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' ./src/captagent || echo "Setcap failed"
+  - sudo chmod u+s ./src/captagent  || echo "chmod u+s failed"
   - ./src/captagent -v
   - cd test && npm install && sudo -s npm test

--- a/test/README.md
+++ b/test/README.md
@@ -1,10 +1,23 @@
 ## CaptAgent CI
 
-Automated tests for Captagent using Node JS and Mocha
+Automated tests for Captagent using Node JS and Mocha.
+
+NOTICE: `sudo` rights are required to spawn the agent and test sockets on interface `any`
 
 ### Usage
 ```
 npm install -g mocha
-npm test
+sudo npm test
 ```
 
+#### Units
+##### Initialization
+This suite will initialized the compiled agent and check it returns a version number.
+```
+sudo mocha init.js
+```
+##### HEP Functionality
+This suite will test SIP and HEP features using the compiled agent, feeding it SIP and expecting HEP back.
+```
+sudo mocha hep.js
+```

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,10 @@
+## CaptAgent CI
+
+Automated tests for Captagent using Node JS and Mocha
+
+### Usage
+```
+npm install -g mocha
+npm test
+```
+

--- a/test/hep.js
+++ b/test/hep.js
@@ -3,7 +3,7 @@ const spawn = require('child_process').spawn
 const hepjs = require('hep-js')
 const dgram = require('dgram')
 const command = '../src/captagent'
-const ipserver = '0.0.0.0'
+const ipserver = '127.0.0.1'
 const iptarget = '127.0.0.1'
 
 /*

--- a/test/hep.js
+++ b/test/hep.js
@@ -17,6 +17,7 @@ describe('CaptAgent HEP Basic', () => {
   let decoded
   let network
   var sipmessage = 'SIP/2.0 200 OK\r\nVia: SIP/2.0/UDP there.com:5060\r\nFrom: LittleGuy <sip:UserB@there.com>\r\nTo: LittleGuy <sip:UserB@there.com>\r\nCall-ID: 123456789@there.com\r\nCSeq: 2 REGISTER\r\n\r\n'
+  var udpmessage = new Buffer(sipmessage);
   var in_socket = dgram.createSocket('udp4')
   var out_socket = dgram.createSocket('udp4')
 
@@ -34,13 +35,16 @@ describe('CaptAgent HEP Basic', () => {
       network = socket;
       captagent.kill();
     })
+    var sendHep = function(){
+	out_socket.send(udpmessage, 0, udpmessage.length, 5060, iptarget, function(err) {
+          if (err) console.log(err);
+	});
+    }
+
     in_socket.on('listening', function () {
-	    captagent.stdout.on('data', (data) => {
-	      // if(!data.includes('ready')) return;
-	      var udpmessage = new Buffer(sipmessage);
-	      out_socket.send(udpmessage, 0, udpmessage.length, 5060, iptarget, function(err) {
-	        if (err) console.log(err);
-    	  });
+	captagent.stdout.on('data', (data) => {
+	     //if(!data.includes('ready')) return;	
+	     setTimeout(sendHep, 1500);
     	})
     })
     in_socket.bind(9061, ipserver)

--- a/test/hep.js
+++ b/test/hep.js
@@ -48,14 +48,17 @@ describe('CaptAgent HEP Basic', () => {
     in_socket.bind(9061, ipserver)
   })
 	
-  it('HEP should originate from 127.0.0.1', () => {
+  it('HEP should originate from 127.0.0.1', (done) => {
     assert.ok(network.address === '127.0.0.1');
+    done();
   })
-  it('should return HEP data', () => {
+  it('should return HEP data', (done) => {
     assert.ok(decoded);
+    done();
   })
-  it('should return HEP payload', () => {
+  it('should return HEP payload', (done) => {
     assert.ok(decoded.payload.length > 0);
+    done();
   })
  })
 

--- a/test/hep.js
+++ b/test/hep.js
@@ -1,0 +1,59 @@
+const assert = require('assert')
+const spawn = require('child_process').spawn
+const hepjs = require('hep-js');
+const dgram = require('dgram');
+const command = '../src/captagent';
+
+/*
+ * Start Captagent, Check Exit Code
+ */
+describe('CaptAgent HEP Basic', () => {
+  let args = [
+    "-n"
+  ]
+
+  let decoded
+  let network
+  var sipmessage = 'SIP/2.0 200 OK\r\nVia: SIP/2.0/UDP there.com:5060\r\nFrom: LittleGuy <sip:UserB@there.com>\r\nTo: LittleGuy <sip:UserB@there.com>\r\nCall-ID: 123456789@there.com\r\nCSeq: 2 REGISTER\r\n\r\n'
+  var in_socket = dgram.createSocket('udp4')
+  var out_socket = dgram.createSocket('udp4')
+
+  before((done) => {
+
+    let captagent = spawn(command, args);
+
+    in_socket.on('message', (message,socket) => {
+      decoded = hepjs.decapsulate(message);
+      network = socket;
+      captagent.kill();
+    })
+    in_socket.on('listening', function () {
+	// console.log('HEP Socket Ready!');
+	    captagent.stdout.on('data', (data) => {
+	      if(!data.includes('ready')) return;
+	      // console.log('Agent up!');
+	      var udpmessage = new Buffer(sipmessage);
+	      out_socket.send(udpmessage, 0, udpmessage.length, 5060, '127.0.0.1', function(err) {
+	        if (err) throw err;
+		// console.log('SIP sent!');
+		// process.kill();
+    	  });
+    	})
+    	captagent.on('close', () => {
+		in_socket.close();
+		out_socket.close();
+		done()
+	})
+
+    })
+    in_socket.bind(9061, '127.0.0.1')
+
+  })
+  it('HEP should originate from 127.0.0.1', () => {
+    assert.ok(network.address === '127.0.0.1');
+  })
+  it('should return HEP data', () => {
+    assert.ok(decoded.payload.length > 0);
+  })
+ })
+

--- a/test/hep.js
+++ b/test/hep.js
@@ -1,8 +1,9 @@
 const assert = require('assert')
 const spawn = require('child_process').spawn
-const hepjs = require('hep-js');
-const dgram = require('dgram');
-const command = '../src/captagent';
+const hepjs = require('hep-js')
+const dgram = require('dgram')
+const command = '../src/captagent'
+const iptarget = '0.0.0.0'
 
 /*
  * Start Captagent, Check Exit Code
@@ -31,7 +32,7 @@ describe('CaptAgent HEP Basic', () => {
 	    captagent.stdout.on('data', (data) => {
 	      if(!data.includes('ready')) return;
 	      var udpmessage = new Buffer(sipmessage);
-	      out_socket.send(udpmessage, 0, udpmessage.length, 5060, '127.0.0.1', function(err) {
+	      out_socket.send(udpmessage, 0, udpmessage.length, 5060, iptarget, function(err) {
 	        if (err) throw err;
     	  });
     	})
@@ -42,7 +43,7 @@ describe('CaptAgent HEP Basic', () => {
 	})
 
     })
-    in_socket.bind(9061, '127.0.0.1')
+    in_socket.bind(9061, iptarget)
   })
 	
   it('HEP should originate from 127.0.0.1', () => {

--- a/test/hep.js
+++ b/test/hep.js
@@ -3,7 +3,8 @@ const spawn = require('child_process').spawn
 const hepjs = require('hep-js')
 const dgram = require('dgram')
 const command = '../src/captagent'
-const iptarget = '0.0.0.0'
+const ipserver = '127.0.0.1'
+const iptarget = '127.0.0.1'
 
 /*
  * Start Captagent, Check Exit Code
@@ -33,7 +34,7 @@ describe('CaptAgent HEP Basic', () => {
 	      if(!data.includes('ready')) return;
 	      var udpmessage = new Buffer(sipmessage);
 	      out_socket.send(udpmessage, 0, udpmessage.length, 5060, iptarget, function(err) {
-	        if (err) throw err;
+	        if (err) done()
     	  });
     	})
     	captagent.on('close', () => {
@@ -43,7 +44,7 @@ describe('CaptAgent HEP Basic', () => {
 	})
 
     })
-    in_socket.bind(9061, iptarget)
+    in_socket.bind(9061, ipserver)
   })
 	
   it('HEP should originate from 127.0.0.1', () => {

--- a/test/hep.js
+++ b/test/hep.js
@@ -23,6 +23,7 @@ describe('CaptAgent HEP Basic', () => {
   before((done) => {
 
     let captagent = spawn(command, args);
+    let alldone = function(){ done() }
 
     in_socket.on('message', (message,socket) => {
       decoded = hepjs.decapsulate(message);
@@ -34,13 +35,13 @@ describe('CaptAgent HEP Basic', () => {
 	      if(!data.includes('ready')) return;
 	      var udpmessage = new Buffer(sipmessage);
 	      out_socket.send(udpmessage, 0, udpmessage.length, 5060, iptarget, function(err) {
-	        if (err) done()
+	        if (err) console.log(err);
     	  });
     	})
-    	captagent.on('close', () => {
+    	captagent.on('exit', () => {
 		in_socket.close();
 		out_socket.close();
-		done()
+		alldone()
 	})
 
     })

--- a/test/hep.js
+++ b/test/hep.js
@@ -3,7 +3,7 @@ const spawn = require('child_process').spawn
 const hepjs = require('hep-js')
 const dgram = require('dgram')
 const command = '../src/captagent'
-const ipserver = '127.0.0.1'
+const ipserver = '0.0.0.0'
 const iptarget = '127.0.0.1'
 
 /*
@@ -51,6 +51,9 @@ describe('CaptAgent HEP Basic', () => {
     assert.ok(network.address === '127.0.0.1');
   })
   it('should return HEP data', () => {
+    assert.ok(decoded);
+  })
+  it('should return HEP payload', () => {
     assert.ok(decoded.payload.length > 0);
   })
  })

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,52 @@
+const assert = require('assert')
+const spawn = require('child_process').spawn
+
+/*
+ * Start Captagent, Check Exit Code
+ */
+describe('CaptAgent', () => {
+  let args = [
+    "-v"
+  ]
+  let exitCode
+
+  before((done) => {
+    let process = spawn('../src/captagent', args)
+    process.on('exit', (code) => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be zero', () => {
+    assert.equal(exitCode, 0)
+  })
+ })
+
+/*
+ * Start Captagent, Check Exit Code
+ */
+describe('CaptAgent Version', () => {
+  let args = [
+    "-v"
+  ]
+  let exitCode
+  let output
+
+  before((done) => {
+    let process = spawn('../src/captagent', args)
+    process.stdout.on('data', function(data) {
+      output = data.toString();
+    });
+    process.on('exit', (code) => {
+      exitCode = code
+      done()
+    })
+  })
+  it('exit code should be zero', () => {
+    assert.equal(exitCode, 0)
+  })
+  it('should print version number', () => {
+    assert.ok(output.length > 0);
+    assert.ok(output.startsWith('version'));
+  })
+ })

--- a/test/init.js
+++ b/test/init.js
@@ -4,7 +4,7 @@ const spawn = require('child_process').spawn
 /*
  * Start Captagent, Check Exit Code
  */
-describe('CaptAgent', () => {
+describe('CaptAgent Initialization', () => {
   let args = [
     "-v"
   ]

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,0 +1,210 @@
+{
+  "name": "captagent-ci",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "binary-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-1.3.2.tgz",
+      "integrity": "sha512-VDhHcpeF1/ZZy1XvDmYD67bBjRNm1gacw+772xNd5BnTH6ax5TzlDV5dl7216/UlQXQoN9vug07ehk7e0PhNUw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hep-js": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/hep-js/-/hep-js-1.0.11.tgz",
+      "integrity": "sha512-lIXq11gdAjIIGHbykE6x3TCp2ozTCYwAKkhK71/mZawBGs30CwvcpnT/5ai7JxODUlHJb3F1uglXmYIiYX5RWA==",
+      "dev": true,
+      "requires": {
+        "binary-parser": "1.3.2"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "captagent-ci",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "captagent-ci",
+  "version": "1.0.0",
+  "description": "Captagent CI Tests",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha index.js"
+  },
+  "keywords": [
+    "hep",
+    "captagent",
+    "sipcapture",
+    "homer",
+    "test",
+    "ci"
+  ],
+  "author": "Lorenzo Mangani <lorenzo.mangani@gmail.com> (http://qxip.net/)",
+  "license": "GPLv3"
+}

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captagent-ci",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Captagent CI Tests",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
   "author": "Lorenzo Mangani <lorenzo.mangani@gmail.com> (http://qxip.net/)",
   "license": "GPLv3",
   "devDependencies": {
-    "hep-js": "^1.0.11"
+    "hep-js": "^1.0.11",
+    "mocha": "^5.0.1"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captagent-ci",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Captagent CI Tests",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "ci"
   ],
   "author": "Lorenzo Mangani <lorenzo.mangani@gmail.com> (http://qxip.net/)",
-  "license": "GPLv3",
+  "license": "GPL-3.0",
   "devDependencies": {
     "hep-js": "^1.0.11",
     "mocha": "^5.0.1"

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "Captagent CI Tests",
   "main": "index.js",
   "scripts": {
-    "test": "mocha index.js"
+    "test": "mocha *.js"
   },
   "keywords": [
     "hep",
@@ -15,5 +15,8 @@
     "ci"
   ],
   "author": "Lorenzo Mangani <lorenzo.mangani@gmail.com> (http://qxip.net/)",
-  "license": "GPLv3"
+  "license": "GPLv3",
+  "devDependencies": {
+    "hep-js": "^1.0.11"
+  }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "Captagent CI Tests",
   "main": "index.js",
   "scripts": {
-    "test": "mocha *.js"
+    "test": "mocha --timeout 5000 *.js"
   },
   "keywords": [
     "hep",


### PR DESCRIPTION
This skeleton provides a setup for testing Captagent builds for basic and advanced issues using `nodejs` and `mocha` including HEP dissection with `hep-js` for deep validation of HEP IN/OUT pipelines. 
Lots of work still to be done but this is a start. Instructions in `README` inside the `/test` folder.