### PR TITLE
Fix pthread hang in pcap module teardown

### DIFF
--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -1482,6 +1482,7 @@ static int unload_module(void) {
 
 		if(sniffer_proto[i]) {
   		    pcap_breakloop(sniffer_proto[i]);
+  		    pthread_cancel(call_thread[i]);
   		    pthread_join(call_thread[i],NULL);
 		}
 


### PR DESCRIPTION
Without this patch, sending SIGTERM causes captagent to hang on shutdown of the pcap socket module.  Tested on debian buster.

calling pcap_breakloop from a seperate pthread requires the pthreads running pcap_loop to be pthread_cancel'd.  From the pcap_breakloop manpage:

> Note  also  that, in a multi-threaded application, if one thread is blocked in pcap_dispatch(), pcap_loop(), pcap_next(), or pcap_next_ex(), a call to pcap_breakloop() in a different thread will not
>        unblock that thread; you will need to use whatever mechanism the OS provides for breaking a thread out of blocking calls in order to unblock the thread, such as thread cancellation in  systems  that
>        support POSIX threads.

This one-liner fixes the behaviour on my Debian 10 systems