### PR TITLE
Seg Fault while using socket_pcap and receiving 802.1q VLAN tagged traffic

### DIFF
--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -405,8 +405,8 @@ void callback_proto(u_char *arg, struct pcap_pkthdr *pkthdr, u_char *packet) {
     if (eth) {
         snprintf(mac_src, sizeof(mac_src), "%.2X-%.2X-%.2X-%.2X-%.2X-%.2X", eth->ether_shost[0], eth->ether_shost[1], eth->ether_shost[2], eth->ether_shost[3], eth->ether_shost[4], eth->ether_shost[5]);
         snprintf(mac_dst, sizeof(mac_dst), "%.2X-%.2X-%.2X-%.2X-%.2X-%.2X", eth->ether_dhost[0], eth->ether_dhost[1], eth->ether_dhost[2], eth->ether_dhost[3], eth->ether_dhost[4], eth->ether_dhost[5]);
-        if(vlan == 0) {
-            // IP TYPE = 0x86dd (IPv6) or 0x0800 (IPv4)
+        if(vlan == 0 || vlan == 2) {
+            // IP TYPE = 0x86dd (IPv6) or 0x0800 (IPv4) or (0x8100 VLAN)
             type_ip = ntohs(eth->ether_type);
         }
     }
@@ -422,7 +422,7 @@ void callback_proto(u_char *arg, struct pcap_pkthdr *pkthdr, u_char *packet) {
     /** IP LAYER **/
     
  ip_hdr_parse:
-    if(type_ip == ETHERTYPE_IP) {
+    if(type_ip == ETHERTYPE_IP || type_ip == ETHERTYPE_VLAN) {
         ip4_pkt = (struct ip *)(packet + link_offset + hdr_offset + ipip_offset);
     } else {
         #if USE_IPv6


### PR DESCRIPTION
New captagent setup using PCAP and receiving port mirrored traffic from several ports in the environment.  Some ports with VLAN tags, and others without.  Captagent was crashing with a SegFault whenever a packet with the 802.1Q (Ethertype 0x8100) header arrived.  GDB output below of the crash.

The changes in this PR got things running nicely for me.   Heplify had already worked perfectly with this mirrored traffic, but I have a desire to use for output_json for something else so I want to use captagent instead.   Thanks for the great projects!

```
gdb
Core was generated by `/usr/local/captagent/sbin/captagent -f /etc/captagent/captagent.xml'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  callback_proto (arg=<optimized out>, pkthdr=0x7f413282ee00, packet=0x7f4132830082 <error: Cannot access memory at address 0x7f4132830082>) at socket_pcap.c:466
466         ip_ver = ip4_pkt->ip_v;
```

![image](https://user-images.githubusercontent.com/304900/103483807-c7b7d680-4db7-11eb-964d-b44786bc650e.png)
