### PR TITLE
socket/pcap: Re-add SLL2 dlt

### DIFF
--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -1244,6 +1244,10 @@ void* proto_collect(void *arg) {
             link_offset = SLL_HDR_LEN;
             break;
 
+        case DLT_LINUX_SLL2:
+            link_offset = SLL2_HDR_LEN;
+            break;
+
         case DLT_IEEE802_11:
             link_offset = IEEE80211HDR_SIZE;
             break;


### PR DESCRIPTION
As mentioned by @kYroL01 SLL2 DLT is needed for reading PCAPs.