### PR TITLE
socket/pcap: Define SLL2 for old libpcap versions

### DIFF
--- a/src/modules/socket/pcap/socket_pcap.h
+++ b/src/modules/socket/pcap/socket_pcap.h
@@ -58,6 +58,14 @@ union mpls {
   struct mpls_header mpls;
 };
 
+#ifndef DLT_LINUX_SLL2
+#define DLT_LINUX_SLL2 276
+#endif
+
+#ifndef SLL2_HDR_LEN
+#define SLL2_HDR_LEN 20
+#endif
+
 /* header offsets */
 #define ETHHDR_SIZE       14
 #define TOKENRING_SIZE    22


### PR DESCRIPTION
related to #260 @kYroL01 