### PR TITLE
socket/pcap: Define SLL2 struct

### DIFF
--- a/src/modules/socket/pcap/socket_pcap.h
+++ b/src/modules/socket/pcap/socket_pcap.h
@@ -64,6 +64,16 @@ union mpls {
 
 #ifndef SLL2_HDR_LEN
 #define SLL2_HDR_LEN 20
+
+struct sll2_header {
+	uint16_t sll2_protocol;			/* protocol */
+	uint16_t sll2_reserved_mbz;		/* reserved - must be zero */
+	uint32_t sll2_if_index;			/* 1-based interface index */
+	uint16_t sll2_hatype;			/* link-layer address type */
+	uint8_t  sll2_pkttype;			/* packet type */
+	uint8_t  sll2_halen;			/* link-layer address length */
+	uint8_t  sll2_addr[SLL_ADDRLEN];	/* link-layer address */
+};
 #endif
 
 /* header offsets */


### PR DESCRIPTION
fixes #262 

https://github.com/the-tcpdump-group/libpcap/commit/8cff296dc7c321c76933359d586dbde5b580ce8c#diff-71e2d278108185f61bfa3965238988c3b2a9f479a7582e87488af35be15444e7