### PR TITLE
Adding correlation_id as parameter in transport_hep

### DIFF
--- a/include/captagent/modules_api.h
+++ b/include/captagent/modules_api.h
@@ -206,6 +206,7 @@ typedef struct profile_transport {
     int udp_bind_port;
     unsigned int capt_id;
     char *capt_password;
+    char *correlation_id;
     int compression;
     char *statistic_pipe;
     char *statistic_profile;

--- a/src/modules/transport/hep/transport_hep.c
+++ b/src/modules/transport/hep/transport_hep.c
@@ -1456,6 +1456,10 @@ static int free_profile(unsigned int idx) {
         free(profile_transport[idx].capt_password);
         profile_transport[idx].capt_password = NULL;
     }
+    if (profile_transport[idx].correlation_id) {
+        free(profile_transport[idx].correlation_id);
+        profile_transport[idx].correlation_id = NULL;
+    }
 	if (profile_transport[idx].statistic_pipe) {
         free(profile_transport[idx].statistic_pipe);
         profile_transport[idx].statistic_pipe = NULL;

--- a/src/modules/transport/hep/transport_hep.c
+++ b/src/modules/transport/hep/transport_hep.c
@@ -449,6 +449,11 @@ int send_hepv3 (rc_info_t *rcinfo, unsigned char *data, unsigned int len, unsign
     }
 
     /* correlation key */
+    if (profile_transport[idx].correlation_id != NULL) {
+           rcinfo->correlation_id.s = profile_transport[idx].correlation_id;
+           rcinfo->correlation_id.len = strlen(rcinfo->correlation_id.s);
+    }
+
     if (rcinfo->correlation_id.s && rcinfo->correlation_id.len > 0) {
 
              tlen += sizeof(hep_chunk_t);
@@ -529,6 +534,11 @@ int send_hepv3 (rc_info_t *rcinfo, unsigned char *data, unsigned int len, unsign
     }
 
     /* Correlation KEY CHUNK */
+    if (profile_transport[idx].correlation_id != NULL) {
+           rcinfo->correlation_id.s = profile_transport[idx].correlation_id;
+           rcinfo->correlation_id.len = strlen(rcinfo->correlation_id.s);
+    }
+
     if (rcinfo->correlation_id.s && rcinfo->correlation_id.len > 0) {
 
            memcpy((void*) buffer+buflen, &correlation_chunk,  sizeof(struct hep_chunk));
@@ -1299,6 +1309,7 @@ static int load_module(xml_node *config) {
                     else if (!strncmp(key, "capture-password", 17)) profile_transport[profile_size].capt_password = strdup(value);
                     else if (!strncmp(key, "capture-id", 11)) profile_transport[profile_size].capt_id = atoi(value);
                     else if (!strncmp(key, "payload-compression", 19) && !strncmp(value, "true", 5)) profile_transport[profile_size].compression = 1;
+                    else if (!strncmp(key, "correlation-id", 15)) profile_transport[profile_size].correlation_id = strdup(value);
                     else if (!strncmp(key, "version", 7)) profile_transport[profile_size].version = atoi(value);
 
                 }

--- a/src/modules/transport/hep/transport_hep.c
+++ b/src/modules/transport/hep/transport_hep.c
@@ -534,11 +534,6 @@ int send_hepv3 (rc_info_t *rcinfo, unsigned char *data, unsigned int len, unsign
     }
 
     /* Correlation KEY CHUNK */
-    if (profile_transport[idx].correlation_id != NULL) {
-           rcinfo->correlation_id.s = profile_transport[idx].correlation_id;
-           rcinfo->correlation_id.len = strlen(rcinfo->correlation_id.s);
-    }
-
     if (rcinfo->correlation_id.s && rcinfo->correlation_id.len > 0) {
 
            memcpy((void*) buffer+buflen, &correlation_chunk,  sizeof(struct hep_chunk));


### PR DESCRIPTION
In some cases it would be interesting to add '<param name="correlation-id" value="mycorrelation_id"/>' in transport_hep.xml in order to correlate the captured traffic from different sources. 