### PR TITLE
Potential fix for code scanning alert no. 13: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/src/modules/interface/http/civetweb.c
+++ b/src/modules/interface/http/civetweb.c
@@ -5422,8 +5422,8 @@ int mg_upload(struct mg_connection *conn, const char *destination_dir)
     if ((content_type_header = mg_get_header(conn, "Content-Type")) == NULL ||
         (boundary_start = mg_strcasestr(content_type_header,
                                         "boundary=")) == NULL ||
-        (sscanf(boundary_start, "boundary=\"%99[^\"]\"", boundary) == 0 &&
-         sscanf(boundary_start, "boundary=%99s", boundary) == 0) ||
+        (sscanf(boundary_start, "boundary=\"%99[^\"]\"", boundary) != 1 &&
+         sscanf(boundary_start, "boundary=%99s", boundary) != 1) ||
         boundary[0] == '\0') {
         return num_uploaded_files;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/captagent/security/code-scanning/13](https://github.com/sipcapture/captagent/security/code-scanning/13)

Use `sscanf(...) != expected_matches` style checks instead of `== 0`.  
Here, each `sscanf` call is expected to match **one** item (`boundary`), so each call should be considered successful only when it returns `1`.

Best minimal fix (no behavior change intended beyond correctness):
- In `src/modules/interface/http/civetweb.c`, inside `mg_upload` at the multipart boundary extraction `if` condition (around lines 5425–5426), replace both `== 0` checks with `!= 1`.
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
