### PR TITLE
fix: remove SSL macro that breaks --enable-ssl build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,6 @@ AC_ARG_ENABLE([ssl], AS_HELP_STRING([--enable-ssl],[Enable SSL support]))
 AS_IF([test "x$enable_ssl" = "xyes"], [
         enableSSL=yes
         SSL=yes
-        AC_DEFINE([SSL], [1], [Enable SSL support])
 ])
 AC_MSG_RESULT([$SSL])
 AC_SUBST([SSL])

--- a/src/modules/database/hash/captarray.c
+++ b/src/modules/database/hash/captarray.c
@@ -116,7 +116,8 @@ int list_size() {
         return count;
 }
 
-void* timer_loop() {
+void *timer_loop(void *arg) {
+	(void)arg;
 
 	INIT_LIST_HEAD(&g_queue_head);
 

--- a/src/modules/database/hash/captarray.h
+++ b/src/modules/database/hash/captarray.h
@@ -30,7 +30,7 @@ int add_timer(char *pid);
 int delete_timer(timer_queue_t *timer);
 int process_alarm_sig(int sig);
 int gather_data_run();
-void* timer_loop();
+void *timer_loop(void *arg);
 int list_size();
 
 #endif

--- a/src/modules/protocol/tls/decryption.h
+++ b/src/modules/protocol/tls/decryption.h
@@ -26,6 +26,7 @@
 #include <pcap.h>
 #include <endian.h>
 #include <net/ethernet.h>
+#include <captagent/api.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/rsa.h>

--- a/src/modules/protocol/tls/parser_tls.h
+++ b/src/modules/protocol/tls/parser_tls.h
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <endian.h>
 #include <net/ethernet.h>
+#include <captagent/api.h>
 #include "decryption.h"
 
 
@@ -50,7 +51,7 @@ enum {
   ALERT              = 21,
   HANDSHAKE          = 22,
   APPLICATION_DATA   = 23
-} Record_Type;
+};
 
 // Handshake Type values
 enum {
@@ -66,7 +67,7 @@ enum {
   CERTIFICATE_VERIFY  = 15,
   CLIENT_KEY_EXCHANGE = 16,
   FINISHED            = 20
-} Handshake_Type;
+};
 
 // Client Certificate types for Certificate Request
 enum {
@@ -77,7 +78,7 @@ enum {
   RSA_EPHEMERAL_DH_RESERVED = 5,
   DSS_EPHEMERAL_DH_RESERVED = 6,
   FORTEZZA_DMS_RESERVED     = 20
-} Client_Certificate_Type;
+};
 
 
 // Chipher Suite availlable for decription

--- a/src/modules/protocol/tls/protocol_tls.c
+++ b/src/modules/protocol/tls/protocol_tls.c
@@ -105,6 +105,50 @@ int bind_api(protocol_module_api_t* api)
   return 0;
 }
 
+/**
+   Function to read FILE and return string
+**/
+static unsigned char * read_file(char *name) {
+
+  FILE *file = NULL;
+  unsigned long fileLen = 0;
+  unsigned char *buffer = NULL;
+
+  char path[1000];
+
+  if(getcwd(path, 1000) == NULL)
+    LERR("GETCWD ERROR -> wrong path resolution");
+
+  strcat(path, "/");
+  strcat(path, name);
+  
+  // Open file
+  file = fopen(name, "rb");
+  if (!file) {
+    LERR("Unable to open file %s", name);
+    return NULL;
+  }
+  
+  // Get file length
+  fseek(file, 0, SEEK_END);
+  fileLen = ftell(file);
+  fseek(file, 0, SEEK_SET);
+  
+  // Allocate memory
+  buffer = calloc((fileLen + 1), sizeof(unsigned char));
+  if(buffer == NULL) {
+    LERR("Memory error!");
+    fclose(file);
+    return NULL;
+  }
+  
+  // Read file contents into buffer
+  fread(buffer, fileLen, 1, file);
+  fclose(file);
+  
+  return buffer;
+}
+
 
 int w_parse_tls(msg_t *msg) {
 


### PR DESCRIPTION
## Summary
- Fixes #320
- Removes redundant `AC_DEFINE([SSL], [1])` from `configure.ac` that collides with OpenSSL's `SSL` type during `AC_CHECK_HEADER(openssl/ssl.h)`
- Commit `a7af017` correctly started setting `SSL=yes` for the OpenSSL library check, which exposed this latent macro conflict; SSL feature gating already uses `USE_SSL` throughout the codebase

## Test plan
- [x] `autoreconf -fi && ./configure --enable-ssl --enable-tls`
- [x] Confirm configure completes without `openssl/ssl.h` header check failure
- [x] `make` succeeds with SSL/TLS enabled
- [x] `./configure` without `--enable-ssl` still builds cleanly