### PR TITLE
fix: resolve open CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/star.yml
+++ b/.github/workflows/star.yml
@@ -2,6 +2,8 @@ name: Starring Partner
 on:
   issues:
     types: [opened, reopened]
+permissions:
+  issues: write
 jobs:
   # This workflow checks if a user has starred a repository and takes actions
   starcheck:

--- a/src/captagent.c
+++ b/src/captagent.c
@@ -195,7 +195,8 @@ static void print_all_devices()
 
 int get_basestat(char *module, char *buf, size_t len)
 {
-    int pos = 0, ret = 0;
+    size_t pos = 0;
+    int ret = 0;
     char stats[200];
 
     struct module *m = NULL;
@@ -204,13 +205,18 @@ int get_basestat(char *module, char *buf, size_t len)
 
         if (!strncmp(module, "all", 3)) {
             if (m->stats_f(stats, sizeof(stats))) {
-                pos += snprintf(buf + pos, len - pos, "%s\r\n", stats);
+                int n = snprintf(buf + pos, len - pos, "%s\r\n", stats);
+                if (n < 0 || (size_t)n >= len - pos)
+                    return 0;
+                pos += (size_t)n;
                 ret = 1;
             }
         } else {
             if (!strncmp(m->name, module, strlen(module))) {
                 if (m->stats_f(stats, sizeof(stats))) {
-                    ret = snprintf(buf, len, "%s\r\n", stats);
+                    int n = snprintf(buf, len, "%s\r\n", stats);
+                    if (n < 0 || (size_t)n >= len)
+                        return 0;
                     ret = 1;
                     break;
                 }

--- a/src/modules/protocol/rtcp/parser_rtcp.c
+++ b/src/modules/protocol/rtcp/parser_rtcp.c
@@ -23,8 +23,30 @@
  *
  */
 #include <stdio.h>
+#include <stdarg.h>
 #include <captagent/log.h>
 #include "parser_rtcp.h"
+
+static int json_buf_append(char *buf, int buf_len, int *pos, const char *fmt, ...)
+{
+    va_list ap;
+    int avail;
+    int n;
+
+    if (*pos < 0 || *pos >= buf_len)
+        return -1;
+
+    avail = buf_len - *pos;
+    va_start(ap, fmt);
+    n = vsnprintf(buf + *pos, (size_t)avail, fmt, ap);
+    va_end(ap);
+
+    if (n < 0 || n >= avail)
+        return -1;
+
+    *pos += n;
+    return 0;
+}
 
 
 int check_rtcp_version (char *packet, int len) {
@@ -70,7 +92,9 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
   rtcp_header_t *rtcp = (rtcp_header_t *)packet;
   int ret = 0, flag = 0;
 
-  ret += snprintf(json_buffer, buffer_len, "{ ");
+  ret = snprintf(json_buffer, buffer_len, "{ ");
+  if (ret < 0 || ret >= buffer_len)
+    return -1;
 
   int pno = 0, total = len;
   LDEBUG("Parsing compound packet (total of %d bytes)\n", total);
@@ -92,12 +116,13 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
       LDEBUG("#%d SR (200)\n", pno);
       rtcp_sr_t *sr = (rtcp_sr_t*)rtcp;
 
-      ret += snprintf(json_buffer+ret, buffer_len - ret, SENDER_REPORT_JSON,
+      if (json_buf_append(json_buffer, buffer_len, &ret, SENDER_REPORT_JSON,
 		      sender_info_get_ntp_timestamp_msw(&sr->si),
 		      sender_info_get_ntp_timestamp_lsw(&sr->si),
 		      sender_info_get_octet_count(&sr->si),
 		      sender_info_get_rtp_timestamp(&sr->si),
-		      sender_info_get_packet_count(&sr->si));
+		      sender_info_get_packet_count(&sr->si)) < 0)
+        return -1;
 
       if(sr->header.rc > 0) {
 
@@ -106,7 +131,7 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
               return -1;
           }
 
-	ret += snprintf(json_buffer+ret, buffer_len - ret, REPORT_BLOCK_JSON,
+	if (json_buf_append(json_buffer, buffer_len, &ret, REPORT_BLOCK_JSON,
 			ntohl(sr->ssrc), rtcp->type,
 			report_block_get_identifier(&sr->rb[0]),
 			report_block_get_high_ext_seq(&sr->rb[0]),
@@ -114,7 +139,8 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
 			report_block_get_interarrival_jitter(&sr->rb[0]),
 			report_block_get_cum_packet_loss(&sr->rb[0]),
 			report_block_get_last_SR_time(&sr->rb[0]),
-			report_block_get_last_SR_delay(&sr->rb[0]));
+			report_block_get_last_SR_delay(&sr->rb[0])) < 0)
+          return -1;
       }
       break;
     }
@@ -136,7 +162,7 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
               return -1;
           }
 
-	ret += snprintf(json_buffer+ret, buffer_len - ret, REPORT_BLOCK_JSON,
+	if (json_buf_append(json_buffer, buffer_len, &ret, REPORT_BLOCK_JSON,
 			ntohl(rr->ssrc),
 			rtcp->type,
 			report_block_get_identifier(&rr->rb[0]),
@@ -145,7 +171,8 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
 			report_block_get_interarrival_jitter(&rr->rb[0]),
 			report_block_get_cum_packet_loss(&rr->rb[0]),
 			report_block_get_last_SR_time(&rr->rb[0]),
-			report_block_get_last_SR_delay(&rr->rb[0]));
+			report_block_get_last_SR_delay(&rr->rb[0])) < 0)
+          return -1;
       }
       break;
     }
@@ -164,8 +191,9 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
                                 ((uint32_t *)rtcp + ntohs(rtcp->length) + 1);
       rtcp_sdes_item_t *rsp, *rspn;
 
-      ret += snprintf(json_buffer+ret, buffer_len - ret, SDES_REPORT_BEGIN_JSON,
-          ntohl(sdes->csrc), sdes->header.rc);
+      if (json_buf_append(json_buffer, buffer_len, &ret, SDES_REPORT_BEGIN_JSON,
+          ntohl(sdes->csrc), sdes->header.rc) < 0)
+        return -1;
 
       rsp = &sdes->item[0];
       if (rsp >= end) break;
@@ -175,13 +203,15 @@ int capt_parse_rtcp(char *packet, int len, char *json_buffer, int buffer_len) {
           rsp = rspn;
           break;
         }
-        ret += snprintf(json_buffer+ret, buffer_len - ret, SDES_REPORT_INFO_JSON,
-            rsp->type, rsp->len, rsp->content);
+        if (json_buf_append(json_buffer, buffer_len, &ret, SDES_REPORT_INFO_JSON,
+            rsp->type, rsp->len, rsp->content) < 0)
+          return -1;
         items++;
       }
       /* cut , off */
       if (items) ret -= 1;
-      ret += snprintf(json_buffer+ret, buffer_len - ret, "],");
+      if (json_buf_append(json_buffer, buffer_len, &ret, "],") < 0)
+        return -1;
 
       break;
     }

--- a/src/modules/protocol/rtcpxr/parser_rtcpxr.c
+++ b/src/modules/protocol/rtcpxr/parser_rtcpxr.c
@@ -24,15 +24,37 @@
 */
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <captagent/log.h>
 #include <arpa/inet.h>
 #include "parser_rtcpxr.h"
+
+static int json_buf_append(char *buf, int buf_len, int *pos, const char *fmt, ...)
+{
+    va_list ap;
+    int avail;
+    int n;
+
+    if (*pos < 0 || *pos >= buf_len)
+        return -1;
+
+    avail = buf_len - *pos;
+    va_start(ap, fmt);
+    n = vsnprintf(buf + *pos, (size_t)avail, fmt, ap);
+    va_end(ap);
+
+    if (n < 0 || n >= avail)
+        return -1;
+
+    *pos += n;
+    return 0;
+}
 
 
 // RTCP-XR check version
 int check_rtcpxr_version(char *packet, int size_payload)
 {
-  u_int8_t offset = 0, is_xr = 0;
+  unsigned int offset = 0, is_xr = 0;
   
   // check param
   if(!packet || size_payload == 0) return -1;
@@ -78,7 +100,7 @@ int check_rtcpxr_version(char *packet, int size_payload)
 // RTCP-XR Parser
 int parse_rtcpxr(char *packet, int size_payload, rc_info_t *rc_info, char json_buffer[], int buffer_len)
 {
-  u_int8_t offset = 0, is_xr = 0;
+  unsigned int offset = 0, is_xr = 0;
   int ret = 0;
   
   // check param
@@ -127,13 +149,14 @@ int parse_rtcpxr(char *packet, int size_payload, rc_info_t *rc_info, char json_b
       is_xr = 1;
 
       // create json buffer
-      ret += snprintf(json_buffer, buffer_len, "{");
+      if (json_buf_append(json_buffer, buffer_len, &ret, "{") < 0)
+        return -1;
       
       // cast the packet to rtcp-xr
       struct rtcp_xr_t *rtcp_xr = (struct rtcp_xr_t *) pp;
 
       // start to parse field and create json array
-      ret += snprintf(json_buffer + ret, buffer_len - ret, EXTENDED_REPORT_JSON,
+      if (json_buf_append(json_buffer, buffer_len, &ret, EXTENDED_REPORT_JSON,
 		      rtcp_header_get_id(&rtcp_xr->block),
 		      rtcp_header_get_loss(&rtcp_xr->block),
 		      rtcp_header_discard(&rtcp_xr->block),
@@ -156,13 +179,15 @@ int parse_rtcpxr(char *packet, int size_payload, rc_info_t *rc_info, char json_b
 		      rtcp_header_JB_rate(&rtcp_xr->block),
 		      rtcp_header_JB_nom(&rtcp_xr->block),
 		      rtcp_header_JB_max(&rtcp_xr->block),
-		      rtcp_header_JB_abs_max(&rtcp_xr->block));
+		      rtcp_header_JB_abs_max(&rtcp_xr->block)) < 0)
+        return -1;
+      if (json_buf_append(json_buffer, buffer_len, &ret, "}") < 0)
+        return -1;
       break;
     }
   }
-  ret += snprintf(json_buffer + ret - 1, buffer_len - ret + 1, "}");
 
   // update general statistic info **TODO** //
   
-  return strlen(json_buffer);
+  return ret;
 }


### PR DESCRIPTION
- Add explicit workflow permissions to star.yml
- Guard bounded snprintf appends in captagent stats and RTCP parsers
- Use unsigned packet offset in RTCP-XR parser loop conditions