### PR TITLE
fix: guard against null pointer dereference in socket_pcap

### DIFF
--- a/src/modules/socket/pcap/socket_pcap.c
+++ b/src/modules/socket/pcap/socket_pcap.c
@@ -1033,6 +1033,8 @@ bool websocket_header_detection(uint8_t *p_websock, uint32_t posLen, unsigned ch
        Mask 0xF to get the 4 less-significant bit (opcode check)
     **/
 
+    if (p_websock == NULL) return FALSE;
+
     if ((((*p_websock >> 7) & 1) == 1) && (((*p_websock & 0xF) == 0x01) || ((*p_websock & 0xF) == 0x02))) {
 
         /* TCP without payload */
@@ -1056,6 +1058,8 @@ bool websocket_header_detection(uint8_t *p_websock, uint32_t posLen, unsigned ch
 }
 
 bool websocket_pre_decode(uint8_t *p_websock, uint8_t *decoded,  msg_t *_msg) {
+
+    if (p_websock == NULL) return FALSE;
 
     LDEBUG("WEBSOCKET layer found!\n");
     int skip = 0, ws_len = 0, ret;
@@ -1790,6 +1794,11 @@ int w_tzsp_payload_extract(msg_t *_m)
     recv_buffer = _m->data;
     readsz = _m->len;
 
+    if (recv_buffer == NULL || readsz == 0) {
+        LERR("[SOCKET_PCAP] TZSP: NULL or empty data - discard");
+        return -1;
+    }
+
     char *end = recv_buffer + readsz;
     char *p = recv_buffer;
 
@@ -1858,6 +1867,11 @@ int w_tzsp_payload_extract(msg_t *_m)
 
 
 void proccess_packet(msg_t *_m, struct pcap_pkthdr *pkthdr, u_char *packet) {
+
+	if (packet == NULL || pkthdr == NULL) {
+		LERR("[SOCKET_PCAP] proccess_packet: NULL packet or header - discard");
+		return;
+	}
 
 	uint8_t hdr_offset = 0;
 	uint16_t ethaddr;


### PR DESCRIPTION
## Summary

- Adds null guard at entry of `websocket_header_detection()` -- dereferences `p_websock` on the first line with no prior check
- Adds null guard at entry of `websocket_pre_decode()` -- same issue
- Adds null/empty guard in `w_tzsp_payload_extract()` before using `_m->data` as a buffer pointer
- Adds null guard in `proccess_packet()` before any packet/header dereference

## Background

Observed as repeated segfaults on Debian production hosts over June 24--30, 2026. All crashes share an identical signature:

```
segfault at 0 ip <addr+0x186c> in socket_pcap.so error 4
Code: ... 48 8b 45 d0 <0f> b6 00 c0 e8 04 0f b6 c0 ...
```

The faulting instruction (`movzbl (%rax), %eax` + `shr $4, %al`) is the compiler-generated sequence for reading `ip_v` from the first byte of an IP header with `%rax == 0`. The consistent offset confirms a single code path triggered by malformed/TZSP-encapsulated packets whose data pointer arrives as NULL.

## Test plan

- [ ] Build on Debian with `USE_IPv6` enabled and confirm no regression in normal SIP capture
- [ ] Replay a PCAP with fragmented TCP WebSocket traffic and confirm no crash
- [ ] Confirm `socket_pcap.so` offset 0x186c no longer maps to a null-deref path in the new build

🤖 Generated with [Claude Code](https://claude.com/claude-code)